### PR TITLE
Add centos + sbt ci + xgboost image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env.sh
 log/*.log
 .idea
+.vscode/

--- a/sbt-ci/xgboost/Dockerfile
+++ b/sbt-ci/xgboost/Dockerfile
@@ -1,0 +1,48 @@
+FROM centos:7
+
+ENV DOCKER_VER="17.03.2.ce-1"
+ENV SBT_VER="0.13.12"
+ENV DOCKERIZE_VERSION="v0.5.0"
+
+RUN curl -L -o docker-selinux-${DOCKER_VER}.rpm https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-selinux-${DOCKER_VER}.el7.centos.noarch.rpm \
+  && yum install -y docker-selinux-${DOCKER_VER}.rpm \
+  && rm docker-selinux-${DOCKER_VER}.rpm
+
+RUN curl -L -o docker-${DOCKER_VER}.rpm https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-${DOCKER_VER}.el7.centos.x86_64.rpm \
+  && yum install -y docker-${DOCKER_VER}.rpm \
+  && rm docker-${DOCKER_VER}.rpm
+
+RUN curl https://bintray.com/sbt/rpm/rpm | tee /etc/yum.repos.d/bintray-sbt-rpm.repo \
+  && yum install -y sbt-${SBT_VER}
+
+RUN curl -L -o /tmp/mysql57-community-release-el7-11.noarch.rpm https://dev.mysql.com/get/mysql57-community-release-el7-11.noarch.rpm \
+  && yum localinstall -y /tmp/mysql57-community-release-el7-11.noarch.rpm \
+  && yum install -y mysql-community-client
+
+RUN curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip \
+  && yum install -y unzip \
+  && unzip awscli-bundle.zip \
+  && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+
+RUN curl -L -o dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+RUN tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN curl -O http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+RUN rpm -ivh epel-release-7-10.noarch.rpm
+RUN yum update -y && yum install -y \
+    make \
+    gcc gcc-c++ \
+    cmake3 \
+    java-1.8.0-openjdk \
+    java-1.8.0-openjdk-devel \
+    git \
+    maven
+RUN yum clean all
+RUN ln /usr/bin/cmake3 /usr/bin/cmake
+ENV CC=gcc CXX=g++
+
+RUN git clone --recursive https://github.com/dmlc/xgboost
+RUN cd xgboost/jvm-packages && mvn -DskipTests install
+

--- a/sbt-ci/xgboost/Dockerfile
+++ b/sbt-ci/xgboost/Dockerfile
@@ -1,48 +1,37 @@
 FROM centos:7
 
-ENV DOCKER_VER="17.03.2.ce-1"
-ENV SBT_VER="0.13.12"
-ENV DOCKERIZE_VERSION="v0.5.0"
+ENV DOCKER_VER="17.03.2.ce-1" SBT_VER="0.13.12" DOCKERIZE_VERSION="v0.5.0"
 
 RUN curl -L -o docker-selinux-${DOCKER_VER}.rpm https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-selinux-${DOCKER_VER}.el7.centos.noarch.rpm \
   && yum install -y docker-selinux-${DOCKER_VER}.rpm \
-  && rm docker-selinux-${DOCKER_VER}.rpm
-
-RUN curl -L -o docker-${DOCKER_VER}.rpm https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-${DOCKER_VER}.el7.centos.x86_64.rpm \
+  && rm docker-selinux-${DOCKER_VER}.rpm \
+  && curl -L -o docker-${DOCKER_VER}.rpm https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-${DOCKER_VER}.el7.centos.x86_64.rpm \
   && yum install -y docker-${DOCKER_VER}.rpm \
   && rm docker-${DOCKER_VER}.rpm
 
 RUN curl https://bintray.com/sbt/rpm/rpm | tee /etc/yum.repos.d/bintray-sbt-rpm.repo \
-  && yum install -y sbt-${SBT_VER}
+  && yum install -y sbt-${SBT_VER} java-1.8.0-openjdk java-1.8.0-openjdk-devel
 
 RUN curl -L -o /tmp/mysql57-community-release-el7-11.noarch.rpm https://dev.mysql.com/get/mysql57-community-release-el7-11.noarch.rpm \
   && yum localinstall -y /tmp/mysql57-community-release-el7-11.noarch.rpm \
-  && yum install -y mysql-community-client
+  && yum install -y mysql-community-client \
+  && rm /tmp/mysql57-community-release-el7-11.noarch.rpm
 
 RUN curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip \
   && yum install -y unzip \
   && unzip awscli-bundle.zip \
-  && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+  && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
+  && rm -rf ./awscli-bundle.zip ./awscli-bundle
 
 RUN curl -L -o dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN curl -O http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
-RUN rpm -ivh epel-release-7-10.noarch.rpm
-RUN yum update -y && yum install -y \
-    make \
-    gcc gcc-c++ \
-    cmake3 \
-    java-1.8.0-openjdk \
-    java-1.8.0-openjdk-devel \
-    git \
-    maven
-RUN yum clean all
-RUN ln /usr/bin/cmake3 /usr/bin/cmake
-ENV CC=gcc CXX=g++
-
-RUN git clone --recursive https://github.com/dmlc/xgboost
-RUN cd xgboost/jvm-packages && mvn -DskipTests install
+RUN yum install -y epel-release && yum makecache && yum update -y epel-release && yum makecache \
+  && yum install -y make gcc gcc-c++ cmake3 git maven \
+  && yum clean all \
+  && ln /usr/bin/cmake3 /usr/bin/cmake \
+  && git clone --recursive https://github.com/dmlc/xgboost && cd xgboost/jvm-packages \
+  && CC=gcc CXX=g++ mvn -DskipTests install && cd ../.. && rm -rf xgboost
 


### PR DESCRIPTION
This image should be a drop-in replacement of the sbt-ci (https://github.com/pubnative/docker-images/blob/master/sbt-ci/Dockerfile) which is based on the official Java. Instead here we use centos, as it's the same platform that we deploy the actual jobs with.