### PR TITLE
[#39]: Network policy support for ipsec

### DIFF
--- a/vpn/Dockerfile
+++ b/vpn/Dockerfile
@@ -3,6 +3,13 @@
 FROM hwdsl2/ipsec-vpn-server
 MAINTAINER Pubnative Tech <team@pubnative.net>
 
+ENV DESTINATION_NETWORK ""
+ENV ALLOWED_SERVICES ""
+
+RUN apt update \
+    && apt install -y ipset \
+    && rm -rf /var/cache/apt/*
+
 COPY ./run.sh /opt/src/run.sh
 RUN chmod 755 /opt/src/run.sh
 

--- a/vpn/README.md
+++ b/vpn/README.md
@@ -4,3 +4,16 @@
 $ docker build -t pubnative/vpn:3.21 .
 $ docker push pubnative/vpn:3.21
 ```
+
+### Environment variables
+
+
+`DESTINATION_NETWORK` - traffic only to this network will be allowed while routing.
+Example: `10.0.0.0/16`
+
+`ALLOWED_SERVICES` - per-service filter tuning. Allows access to this services from vpn clients.
+Format is: `DESTNET,[proto:]port[ …]`
+Example: `10.20.30.0/24,80 192.168.100.1,udp:53 172.16.0.0/22,vrrp:0 10.20.30.0/23,tcp:6379-6400 10.20.30.0/23,icmp:0 10.20.30.0/23,icmp:3 10.20.30.0/23,icmp:8`
+
+#### See also
+`man ipset(8) #hash:net,port`


### PR DESCRIPTION
Support of ipset with set of ALLOWED_SERVICES via environment.
Format is: `DESTNET,[proto:]port[ …]`.
For example: `10.20.30.0/24,80 192.168.100.1,udp:53 172.16.0.0/22,vrrp:0 10.20.30.0/23,tcp:6379-6400 10.20.30.0/23,icmp:0 10.20.30.0/23,icmp:3 10.20.30.0/23,icmp:8 `