### PR TITLE
VPN image: Fixed typo in Destination variable

### DIFF
--- a/vpn/Dockerfile
+++ b/vpn/Dockerfile
@@ -3,7 +3,7 @@
 FROM hwdsl2/ipsec-vpn-server
 MAINTAINER Pubnative Tech <team@pubnative.net>
 
-ENV DESTINATION_NETWORK ""
+ENV DESTINATION_NET ""
 ENV ALLOWED_SERVICES ""
 
 RUN apt update \

--- a/vpn/README.md
+++ b/vpn/README.md
@@ -7,8 +7,7 @@ $ docker push pubnative/vpn:3.21
 
 ### Environment variables
 
-
-`DESTINATION_NETWORK` - traffic only to this network will be allowed while routing.
+`DESTINATION_NET` - traffic only to this network will be allowed while routing.
 Example: `10.0.0.0/16`
 
 `ALLOWED_SERVICES` - per-service filter tuning. Allows access to this services from vpn clients.


### PR DESCRIPTION
Documentation and Dockerfile fix.

Rename variable DESTINATION_NETWORK to DESTINATION_NET