### PR TITLE
Add an Airflow image for BI

### DIFF
--- a/airflow-bi/Dockerfile
+++ b/airflow-bi/Dockerfile
@@ -1,0 +1,31 @@
+# Image: pubnative/airflow-bi:1.0
+
+FROM pubnative/airflow:python3.7
+
+RUN pip install \
+      "pandas==0.24.1" \
+      sqlalchemy \
+      pyhive \
+      gspread \
+      requests \
+      pygsheets \
+      oauth2client \
+      twilio \
+      boto3 \
+      google-cloud-storage \
+      scipy \
+      bs4 \
+      matplotlib \
+      lxml \
+      xlsxwriter \
+      pydruid \
+      openpyxl \
+      "websocket-client==0.55.0" \
+      "slackclient==1.3.0" \
+      --upgrade pip \
+      xlrd \
+      fastparquet \
+      pyarrow \
+      s3fs
+
+LABEL maintainer Denis <denis@pubnative.net>


### PR DESCRIPTION
Same image as in data Airflow but with some dependencies they need. It's already deployed.

I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
