### PR TITLE
DAT-886 sbt-ci: added clickhouse-client

### DIFF
--- a/sbt-ci/Dockerfile
+++ b/sbt-ci/Dockerfile
@@ -31,13 +31,6 @@ RUN curl -L -o dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN yum install -y epel-release && yum makecache && yum update -y epel-release && yum makecache \
-  && yum install -y make gcc gcc-c++ cmake3 git maven \
-  && yum clean all \
-  && ln /usr/bin/cmake3 /usr/bin/cmake
-
-RUN pip3 install xgboost
-
 RUN curl -L -o /tmp/google-chrome-stable.rpm https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
   && yum install -y /tmp/google-chrome-stable.rpm
 

--- a/sbt-ci/Dockerfile
+++ b/sbt-ci/Dockerfile
@@ -34,9 +34,14 @@ RUN curl -L -o dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
 RUN yum install -y epel-release && yum makecache && yum update -y epel-release && yum makecache \
   && yum install -y make gcc gcc-c++ cmake3 git maven \
   && yum clean all \
-  && ln /usr/bin/cmake3 /usr/bin/cmake 
-RUN git clone --recursive https://github.com/dmlc/xgboost && cd xgboost/jvm-packages \
-  && CC=gcc CXX=g++ mvn -DskipTests install && cd ../.. && rm -rf xgboost
+  && ln /usr/bin/cmake3 /usr/bin/cmake
+
+RUN pip3 install xgboost
 
 RUN curl -L -o /tmp/google-chrome-stable.rpm https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
   && yum install -y /tmp/google-chrome-stable.rpm
+
+RUN yum install -y yum-utils \
+  && rpm --import https://repo.yandex.ru/clickhouse/CLICKHOUSE-KEY.GPG \
+  && yum-config-manager --add-repo https://repo.yandex.ru/clickhouse/rpm/stable/x86_64 \
+  && yum install -y clickhouse-client

--- a/sbt-ci/README.md
+++ b/sbt-ci/README.md
@@ -8,3 +8,4 @@ Contains the following components:
 - docker
 - dockerize
 - mysql-client
+- clickhouse-client


### PR DESCRIPTION
clickhouse-client is needed to test `throttling` and `throttlingApi` in  **spark-jobs** project

After aproval we need to publish image and update **circle.yml**

```
docker build --tag=pubnative/sbt-ci:0.13 .

docker image push pubnative/sbt-ci:0.13

```