### PR TITLE
Fix the werkzeug version

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -8,9 +8,11 @@ FROM pubnative/airflow:python3.7
 
 ENV AIRFLOW_VERSION "1.10.7"
 ENV INFLUX_DB_VERSION "5.2.1"
+ENV WERKZEUG_VERSION "0.15.4"
 
 LABEL maintainer Denis <denis@pubnative.net>
 
 RUN pip3 install \
   apache-airflow[statsd]==${AIRFLOW_VERSION} \
-  influxdb==${INFLUX_DB_VERSION}
+  influxdb==${INFLUX_DB_VERSION} \
+  werkzeug==${WERKZEUG_VERSION}


### PR DESCRIPTION
I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.