### PR TITLE
redis: pre-bake image suitable for redis-cluster deployment

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,0 +1,9 @@
+FROM redis:5.0.7
+
+MAINTAINER PubNative Team <team@pubnative.net>
+
+RUN apt-get update && \
+    apt-get install dnsutils -y && \
+    mkdir /health
+
+COPY liveness.sh readiness.sh /health/

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER PubNative Team <team@pubnative.net>
 
 RUN apt-get update && \
     apt-get install dnsutils -y && \
-    mkdir /health
+    mkdir /health && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY liveness.sh readiness.sh /health/

--- a/redis/liveness.sh
+++ b/redis/liveness.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+NODE_STATE="$(redis-cli ping)x"
+
+if [ "$${NODE_STATE}" == "PONGx" ]; then
+        exit 0
+fi
+
+exit 1

--- a/redis/liveness.sh
+++ b/redis/liveness.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 NODE_STATE="$(redis-cli ping)x"
 
-if [ "$${NODE_STATE}" == "PONGx" ]; then
+if [ "${NODE_STATE}" == "PONGx" ]; then
         exit 0
 fi
 

--- a/redis/liveness.sh
+++ b/redis/liveness.sh
@@ -2,9 +2,9 @@
 
 set -euxo pipefail
 
-NODE_STATE="$(redis-cli ping)x"
+NODE_STATE="$(redis-cli ping)"
 
-if [ "${NODE_STATE}" == "PONGx" ]; then
+if [ "${NODE_STATE}" == "PONG" ]; then
         exit 0
 fi
 

--- a/redis/readiness.sh
+++ b/redis/readiness.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 CLUSTER_STATE=$(redis-cli cluster info | grep cluster_state | tr '\r' 'x')
 
-if [ "$${CLUSTER_STATE}" == "cluster_state:okx" ]; then
+if [ "${CLUSTER_STATE}" == "cluster_state:okx" ]; then
         exit 0
 fi
 

--- a/redis/readiness.sh
+++ b/redis/readiness.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+CLUSTER_STATE=$(redis-cli cluster info | grep cluster_state | tr '\r' 'x')
+
+if [ "$${CLUSTER_STATE}" == "cluster_state:okx" ]; then
+        exit 0
+fi
+
+exit 1


### PR DESCRIPTION
We need to have some kind of dns resolver for utility scripts.

It also makes sense to bake in our liveness/readiness scripts, we can
override them in the worst case but at the same time they provide
reasonable reference implementation.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>