### PR TITLE
redis-exporter: wrap under PN

### DIFF
--- a/redis-exporter/Dockerfile
+++ b/redis-exporter/Dockerfile
@@ -1,0 +1,3 @@
+FROM oliver006/redis_exporter:v1.3.5
+
+MAINTAINER PubNative Team <team@pubnative.net>

--- a/redis-exporter/Makefile
+++ b/redis-exporter/Makefile
@@ -1,0 +1,16 @@
+NAME = pubnative/redis-exporter
+UPSTREAM_IMAGE_VERSION = v1.3.5
+VERSIONED = ${NAME}:${UPSTREAM_IMAGE_VERSION}
+LATEST = ${NAME}:latest
+ALL_COMMANDS = build push
+ 
+all: $(ALL_COMMANDS)
+.PHONY: $(ALL_COMMANDS)
+
+build:
+	docker build --rm . -t ${VERSIONED}
+	docker tag ${VERSIONED} ${LATEST}
+
+push:
+	docker push ${VERSIONED}
+	docker push ${LATEST}

--- a/redis-exporter/README.md
+++ b/redis-exporter/README.md
@@ -1,0 +1,16 @@
+# redis-exporter
+
+Image containing redis-exporter, tool to scrape metrics off Redis.
+Tested with Redis 5+. Versioning follows upstream.
+
+## Build
+
+`make build`
+
+## push
+
+`make push`
+
+## Both
+
+`make all`


### PR DESCRIPTION
The main added value is having "golden build" that shouldn't be easy
to attack. Nothing extra added.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>
