### PR TITLE
Redis: add Makefile and README

### DIFF
--- a/redis/Makefile
+++ b/redis/Makefile
@@ -1,0 +1,16 @@
+NAME = pubnative/redis
+UPSTREAM_IMAGE_VERSION = 5.0.7
+VERSIONED = ${NAME}:${UPSTREAM_IMAGE_VERSION}
+LATEST = ${NAME}:latest
+ALL_COMMANDS = build push
+ 
+all: $(ALL_COMMANDS)
+.PHONY: $(ALL_COMMANDS)
+
+build:
+	docker build --rm . -t ${VERSIONED}
+	docker tag ${VERSIONED} ${LATEST}
+
+push:
+	docker push ${VERSIONED}
+	docker push ${LATEST}

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,0 +1,15 @@
+# redis-exporter
+
+Image containing redis 5.0.7. Versioning follows upstream.
+
+## Build
+
+`make build`
+
+## push
+
+`make push`
+
+## Both
+
+`make all`


### PR DESCRIPTION
Both serve as a convenience, but the Makefile makes building the image
faster.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>