### PR TITLE
awscli: alpine-based image with bash and AWS CLI

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.6
+RUN apk -v --update add \
+        python \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        curl \
+        bash \
+        && \
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*
+VOLUME /root/.aws
+ENTRYPOINT ["/bin/bash"]

--- a/awscli/Makefile
+++ b/awscli/Makefile
@@ -1,0 +1,16 @@
+NAME = pubnative/awscli
+UPSTREAM_IMAGE_VERSION = 1.14.5
+VERSIONED = ${NAME}:${UPSTREAM_IMAGE_VERSION}
+LATEST = ${NAME}:latest
+ALL_COMMANDS = build push
+ 
+all: $(ALL_COMMANDS)
+.PHONY: $(ALL_COMMANDS)
+
+build:
+	docker build --rm . -t ${VERSIONED}
+	docker tag ${VERSIONED} ${LATEST}
+
+push:
+	docker push ${VERSIONED}
+	docker push ${LATEST}

--- a/awscli/README.md
+++ b/awscli/README.md
@@ -1,0 +1,16 @@
+# awscli
+
+Alpine with AWS CLI installed. Useful for scripts that need to reach AWS from
+edge clusters.
+
+## Build
+
+`make build`
+
+## push
+
+`make push`
+
+## Both
+
+`make all`


### PR DESCRIPTION
Image used for scripts that need to reach AWS from edge clusters. Auth
is done through env vars in the same way as AWS CLI expects.

I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
