### PR TITLE
DAT-1035 Add almond kernel to jupyter docker image

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -15,3 +15,11 @@ RUN pip install \
   --require-hashes \
   --ignore-installed \
   -r /tmp/requirements.txt
+
+# install almond kernel
+ENV SCALA_VERSION=2.11.12
+ENV ALMOND_VERSION=0.6.0
+RUN curl -Lo coursier https://git.io/coursier-cli
+RUN chmod +x coursier
+RUN ./coursier bootstrap -r jitpack -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION -o almond-scala-2.11
+RUN ./almond-scala-2.11 --install --id scala211 --display-name "Scala (2.11)"


### PR DESCRIPTION
[DAT-1035](https://pubnativegmbh.atlassian.net/browse/DAT-1035)

* the Almond kernel enables us to import Scala dependencies from different repositories
* we need to install Almond version `0.6.0` since its the last version supporting Scala 2.11
* Scala 2.11 is required since all our packages are running under this version
* install Almond kernel according to the [Almond docs](https://almond.sh/docs/install-multiple)
* successfully tested locally
