### PR TITLE
Add wordpress7.4 image with msmtp installed

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,0 +1,9 @@
+FROM wordpress:php7.4
+
+RUN apt-get update && \
+    apt-get -y install msmtp
+
+COPY sendmail.ini /usr/local/etc/php/conf.d/sendmail.ini
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/wordpress/Makefile
+++ b/wordpress/Makefile
@@ -1,0 +1,16 @@
+NAME = pubnative/wordpress
+UPSTREAM_IMAGE_VERSION = php7.4
+VERSIONED = ${NAME}:${UPSTREAM_IMAGE_VERSION}
+LATEST = ${NAME}:latest
+ALL_COMMANDS = build push
+
+all: $(ALL_COMMANDS)
+.PHONY: $(ALL_COMMANDS)
+
+build:
+	docker build --rm . -t ${VERSIONED}
+	docker tag ${VERSIONED} ${LATEST}
+
+push:
+	docker push ${VERSIONED}
+	docker push ${LATEST}

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,0 +1,18 @@
+# wordpress
+
+Version of wordpress Docker image with msmtp installed and configured as PHP
+sendmail binary. The container (implicitly) expects /etc/msmtprc to exists and
+configure msmtp to send emails (with default account to work with PHP
+sendmail/WP).
+
+## Build
+
+`make build`
+
+## push
+
+`make push`
+
+## Both
+
+`make all`

--- a/wordpress/sendmail.ini
+++ b/wordpress/sendmail.ini
@@ -1,0 +1,1 @@
+sendmail_path = "/usr/bin/msmtp -t"


### PR DESCRIPTION
Our marketing website needs to be able to send emails. `msmtp` seems
like the front runner choice and can be easily configured with php.

We can accomplish this by wrapping wordpress image and installing
msmtp, while also injecting sendmail.ini to PHP location dir.