### PR TITLE
gcloud: add an image with gcloud SDK installed

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.12
+RUN apk -v --update add \
+        python3 \
+        curl \
+        bash && \
+    curl https://sdk.cloud.google.com | CLOUDSDK_CORE_DISABLE_PROMPTS=1 bash && \
+    echo "source /root/google-cloud-sdk/path.bash.inc" > ~/.bashrc && \
+    /root/google-cloud-sdk/bin/gcloud config set disable_usage_reporting false && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*
+ENTRYPOINT ["/bin/bash"]

--- a/gcloud/Makefile
+++ b/gcloud/Makefile
@@ -1,0 +1,16 @@
+NAME = pubnative/gcloud
+IMAGE_VERSION = 0.0.1
+VERSIONED = ${NAME}:${IMAGE_VERSION}
+LATEST = ${NAME}:latest
+ALL_COMMANDS = build push
+ 
+all: $(ALL_COMMANDS)
+.PHONY: $(ALL_COMMANDS)
+
+build:
+	docker build --rm . -t ${VERSIONED}
+	docker tag ${VERSIONED} ${LATEST}
+
+push:
+	docker push ${VERSIONED}
+	docker push ${LATEST}

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -1,0 +1,16 @@
+# gcloud
+
+Alpine with gcloud CLI installed. Useful for scripts that need reach GCP
+services, such as GCS.
+
+## Build
+
+`make build`
+
+## push
+
+`make push`
+
+## Both
+
+`make all`


### PR DESCRIPTION
Some of our scripts will need to reach GCP services, such as GCS.
Instead of relying in community images, the task is small enough to be
done in a minimal image.