### PR TITLE
Create a modern (0.20.0) druid image

### DIFF
--- a/druid_20/Dockerfile
+++ b/druid_20/Dockerfile
@@ -1,0 +1,30 @@
+# Image: pubnative/druid:DRUID_VSN
+# This image is created by backend, please don't confuse it
+# with the one created by data in ../druid
+
+FROM fedora:33
+
+ARG DRUID_VSN
+
+RUN set -exu \
+ && : Install dependencies and some useful packages \
+ && dnf upgrade -y \
+ && dnf install -y bash bind-utils ca-certificates gpg iproute java-1.8.0-openjdk man-db perl-base perl-File-Copy perl-FindBin procps-ng sysstat \
+ && dnf clean all \
+ \
+ && : Install PGP key \
+ && curl -o KEYS https://downloads.apache.org/druid/KEYS \
+ && gpg --import KEYS \
+ \
+ && : Download and verify druid \
+ && curl -Lo druid.tgz "https://www.apache.org/dyn/closer.cgi?action=download&filename=/druid/${DRUID_VSN}/apache-druid-${DRUID_VSN}-bin.tar.gz" \
+ && curl -o druid.tgz.asc https://downloads.apache.org/druid/${DRUID_VSN}/apache-druid-${DRUID_VSN}-bin.tar.gz.asc \
+ && gpg --verify druid.tgz.asc druid.tgz \
+ \
+ && : Install druid \
+ && tar -xzf druid.tgz -C /opt \
+ && rm -f druid.tgz druid.tgz.asc KEYS \
+ && mv /opt/apache-druid-${DRUID_VSN} /opt/druid 
+
+WORKDIR /opt/druid
+

--- a/druid_20/Dockerfile
+++ b/druid_20/Dockerfile
@@ -21,10 +21,17 @@ RUN set -exu \
  && curl -o druid.tgz.asc https://downloads.apache.org/druid/${DRUID_VSN}/apache-druid-${DRUID_VSN}-bin.tar.gz.asc \
  && gpg --verify druid.tgz.asc druid.tgz \
  \
+ && : Create user and group \
+ && groupadd -g 1000 druid \
+ && useradd -d /opt/druid -M -g druid -u 1000 druid \
+ \
  && : Install druid \
  && tar -xzf druid.tgz -C /opt \
  && rm -f druid.tgz druid.tgz.asc KEYS \
- && mv /opt/apache-druid-${DRUID_VSN} /opt/druid 
+ && mv /opt/apache-druid-${DRUID_VSN} /opt/druid \
+ && mkdir /opt/druid/var \
+ && chown -R druid:druid /opt/druid
 
 WORKDIR /opt/druid
+ENTRYPOINT ["runuser", "-u", "druid"]
 

--- a/druid_20/Makefile
+++ b/druid_20/Makefile
@@ -1,0 +1,12 @@
+NAME = druid
+TAG  = $(DRUID_VSN)
+IMAGE = pubnative/$(NAME):$(TAG)
+BUILD_PARAMS = --build-arg DRUID_VSN=${DRUID_VSN}
+
+DRUID_VSN = 0.20.0
+
+build:
+	docker build $(BUILD_PARAMS) -t $(IMAGE) .
+
+push:
+	docker push $(IMAGE)


### PR DESCRIPTION
The official druid image is not able to run `./bin/start-*` commands, which are really handy for creating single node clusters with zookeeper and all the different components in one container.

There is no special steps to build and push, the normal `make build push` should do the thing.

----
I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
