### PR TITLE
Improve Spark building instructions and image naming convention

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -17,17 +17,15 @@ RUN pip install \
   -r /tmp/requirements.txt
 
 # Install almond kernel
-RUN curl -Lo coursier https://git.io/coursier-cli
-RUN chmod +x coursier
+# Check version matrix at: https://almond.sh/docs/install-versions
+RUN curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier
+
 # Scala 2.11
 ENV SCALA_VERSION=2.11.12
 ENV ALMOND_VERSION=0.6.0
-RUN ./coursier bootstrap -r jitpack -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION -o almond-scala-2.11
-# Install almond kernel globally because jupyter home directory will be un-mounted
-RUN ./almond-scala-2.11 --install --id scala211 --display-name "Scala (2.11)" --jupyter-path /opt/conda/share/jupyter/kernels
+RUN ./coursier launch almond:$ALMOND_VERSION --scala $SCALA_VERSION -- --install --id almond_$ALMOND_VERSION_$SCALA_VERSION --display-name "Almond Scala ($ALMOND_VERSION, $SCALA_VERSION)" --jupyter-path /opt/conda/share/jupyter/kernels
 
 # Scala 2.12
-ENV SCALA_VERSION=2.12.12
+ENV SCALA_VERSION=2.12.10
 ENV ALMOND_VERSION=0.10.3
-RUN ./coursier bootstrap -r jitpack -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION -o almond-scala-2.12
-RUN ./almond-scala-2.12 --install --id scala212 --display-name "Scala (2.12)" --jupyter-path /opt/conda/share/jupyter/kernels
+RUN ./coursier launch almond:$ALMOND_VERSION --scala $SCALA_VERSION -- --install --id almond_$ALMOND_VERSION_$SCALA_VERSION --display-name "Almond Scala ($ALMOND_VERSION, $SCALA_VERSION)" --jupyter-path /opt/conda/share/jupyter/kernels

--- a/jupyter/Makefile
+++ b/jupyter/Makefile
@@ -15,7 +15,6 @@ compile_dependencies:
 
 build: compile_dependencies
 	docker build --rm . -t ${IMG}
-	docker tag ${IMG} ${LATEST}
 
 push:
-	docker push ${NAME}
+	docker push ${IMG}

--- a/jupyter/requirements.in
+++ b/jupyter/requirements.in
@@ -1,5 +1,3 @@
-altair==2.4.1
-fbprophet==0.5
 jax==0.1.55
 keras==2.3.1
 matplotlib==3.1.2

--- a/jupyter/requirements.txt
+++ b/jupyter/requirements.txt
@@ -5,71 +5,69 @@
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 #
 absl-py==0.7.1 \
-    --hash=sha256:b943d1c567743ed0455878fcd60bc28ac9fae38d129d1ccfad58079da00b8951 \
-    # via jax, tensorboard, tensorflow
-altair==2.4.1 \
-    --hash=sha256:1fffa057bada5474d733641043edb64182beff71faa2a1b0e68f07f575ebed7c \
-    --hash=sha256:ec62eb75df5adb619b9651dbefbdc130e37004508c7ca48da21863100ab114d3 \
-    # via -r requirements.in
+    --hash=sha256:b943d1c567743ed0455878fcd60bc28ac9fae38d129d1ccfad58079da00b8951
+    # via
+    #   jax
+    #   tensorboard
+    #   tensorflow
 appdirs==1.4.3 \
     --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
-    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e
     # via black
 appnope==0.1.0 \
     --hash=sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0 \
-    --hash=sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71 \
+    --hash=sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71
     # via ipython
-astor==0.7.1 \
-    --hash=sha256:95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d \
-    --hash=sha256:fb503b9e2fdd05609fbf557b916b4a7824171203701660f0c55bbf5a7a68713e \
+astor==0.8.1 \
+    --hash=sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5 \
+    --hash=sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e
     # via tensorflow
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
-    --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via black, jsonschema
+    --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399
+    # via black
 backcall==0.1.0 \
     --hash=sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4 \
-    --hash=sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2 \
+    --hash=sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2
     # via ipython
 black==19.10b0 \
     --hash=sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b \
-    --hash=sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539 \
+    --hash=sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539
     # via nb-black
 boto3==1.10.40 \
     --hash=sha256:8a3b9bb731270888271cd3e0de8d96b35db86be55cfd47296087a074ff23ea86 \
-    --hash=sha256:e8f02208f0127dd73443b8518aacd8207563576e6f6b245a621fdf5080acd5fb \
+    --hash=sha256:e8f02208f0127dd73443b8518aacd8207563576e6f6b245a621fdf5080acd5fb
     # via pyathena
 botocore==1.13.40 \
     --hash=sha256:0f30d5f09181231166c4e74ba7335d0740e1645c4354d76271fde0cad606d8a4 \
-    --hash=sha256:7e44f4c527c11c90942b3ea32ef4577596b08e77d01ab3f9a260b4873402a84d \
-    # via boto3, pyathena, s3transfer
-cachetools==3.1.1 \
-    --hash=sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae \
-    --hash=sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a \
+    --hash=sha256:7e44f4c527c11c90942b3ea32ef4577596b08e77d01ab3f9a260b4873402a84d
+    # via
+    #   boto3
+    #   pyathena
+    #   s3transfer
+cachetools==4.2.2 \
+    --hash=sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001 \
+    --hash=sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff
     # via google-auth
-certifi==2019.9.11 \
-    --hash=sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50 \
-    --hash=sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef \
+certifi==2021.5.30 \
+    --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee \
+    --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8
     # via requests
-chardet==3.0.4 \
-    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
-    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
+chardet==4.0.0 \
+    --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
+    --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
     # via requests
 click==7.0 \
     --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
-    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7
     # via black
 cloudpickle==1.1.1 \
     --hash=sha256:7d43c4d0c7e9735ee8a352c96f84031dabd6676170c4e5e0585a469cc4769f22 \
-    --hash=sha256:d119fb6627e65d43541bdf927975a0f2a5d40074a30d691c8585f761d721bf49 \
+    --hash=sha256:d119fb6627e65d43541bdf927975a0f2a5d40074a30d691c8585f761d721bf49
     # via tensorflow-probability
-convertdate==2.2.0 \
-    --hash=sha256:9d2b0cd8d5382d2458d4cfa59665abba398a9e9bfd3a01c6f61b7b47768d28bf \
-    --hash=sha256:fc34133ef6ceb31738cf1169b528ba487d0164d69f4451a7cef206887c45b71d \
-    # via fbprophet
 cycler==0.10.0 \
     --hash=sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d \
-    --hash=sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8 \
+    --hash=sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8
     # via matplotlib
 cython==0.29.14 \
     --hash=sha256:03f6bbb380ad0acb744fb06e42996ea217e9d00016ca0ff6f2e7d60f580d0360 \
@@ -103,96 +101,101 @@ cython==0.29.14 \
     --hash=sha256:e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414 \
     --hash=sha256:e8fab9911fd2fa8e5af407057cb8bdf87762f983cba483fa3234be20a9a0af77 \
     --hash=sha256:f3818e578e687cdb21dc4aa4a3bc6278c656c9c393e9eda14dd04943f478863d \
-    --hash=sha256:fe666645493d72712c46e4fbe8bec094b06aec3c337400479e9704439c9d9586 \
-    # via fbprophet, pystan
+    --hash=sha256:fe666645493d72712c46e4fbe8bec094b06aec3c337400479e9704439c9d9586
+    # via pystan
 decorator==4.4.0 \
     --hash=sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de \
-    --hash=sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6 \
-    # via ipython, tensorflow-probability, traitlets
+    --hash=sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6
+    # via
+    #   ipython
+    #   tensorflow-probability
+    #   traitlets
 docutils==0.15.2 \
     --hash=sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0 \
     --hash=sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827 \
-    --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99 \
+    --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99
     # via botocore
-entrypoints==0.3 \
-    --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
-    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
-    # via altair
 fastcache==1.1.0 \
-    --hash=sha256:6de1b16e70335b7bde266707eb401a3aaec220fb66c5d13b02abf0eab8be782b \
+    --hash=sha256:6de1b16e70335b7bde266707eb401a3aaec220fb66c5d13b02abf0eab8be782b
     # via jax
-fbprophet==0.5 \
-    --hash=sha256:c67fde2845db52dbdb4becd312b271575ce1c804be666ed1eee94339c5a35127 \
-    # via -r requirements.in
 future==0.18.2 \
-    --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d \
+    --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
     # via pyathena
 gast==0.2.2 \
-    --hash=sha256:fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0 \
-    # via tensorflow, tensorflow-probability
-google-auth-oauthlib==0.4.1 \
-    --hash=sha256:88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd \
-    --hash=sha256:a92a0f6f41a0fb6138454fbc02674e64f89d82a244ea32f98471733c8ef0e0e1 \
+    --hash=sha256:fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0
+    # via
+    #   tensorflow
+    #   tensorflow-probability
+google-auth-oauthlib==0.4.4 \
+    --hash=sha256:09832c6e75032f93818edf1affe4746121d640c625a5bef9b5c96af676e98eee \
+    --hash=sha256:0e92aacacfb94978de3b7972cf4b0f204c3cd206f74ddd0dc0b31e91164e6317
     # via tensorboard
-google-auth==1.7.1 \
-    --hash=sha256:84105be98837fb8436e9d0bcb7a279fd85fa1d97bb35a077e70ba2fb95bcc983 \
-    --hash=sha256:baf1b3f8b29a5f96f66753ad848473699322b63f4d68964e510554b12d002443 \
-    # via google-auth-oauthlib, tensorboard
-google-pasta==0.1.8 \
-    --hash=sha256:41bbe63bab92408452585ff2e1673ec1e35b88e163371cbed2a18510be4e8bc5 \
-    --hash=sha256:644dcf3784cf7147ab01de5dc22e60a638d219d4e4a3a7464eb98997ae2fe66f \
-    --hash=sha256:713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb \
+google-auth==1.30.1 \
+    --hash=sha256:044d81b1e58012f8ebc71cc134e191c1fa312f543f1fbc99973afe28c25e3228 \
+    --hash=sha256:b3ca7a8ff9ab3bdefee3ad5aefb11fc6485423767eee016f5942d8e606ca23fb
+    # via
+    #   google-auth-oauthlib
+    #   tensorboard
+google-pasta==0.2.0 \
+    --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \
+    --hash=sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed \
+    --hash=sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e
     # via tensorflow
-grpcio==1.25.0 \
-    --hash=sha256:0419ae5a45f49c7c40d9ae77ae4de9442431b7822851dfbbe56ee0eacb5e5654 \
-    --hash=sha256:1e8631eeee0fb0b4230aeb135e4890035f6ef9159c2a3555fa184468e325691a \
-    --hash=sha256:24db2fa5438f3815a4edb7a189035051760ca6aa2b0b70a6a948b28bfc63c76b \
-    --hash=sha256:2adb1cdb7d33e91069517b41249622710a94a1faece1fed31cd36904e4201cde \
-    --hash=sha256:2cd51f35692b551aeb1fdeb7a256c7c558f6d78fcddff00640942d42f7aeba5f \
-    --hash=sha256:3247834d24964589f8c2b121b40cd61319b3c2e8d744a6a82008643ef8a378b1 \
-    --hash=sha256:3433cb848b4209717722b62392e575a77a52a34d67c6730138102abc0a441685 \
-    --hash=sha256:39671b7ff77a962bd745746d9d2292c8ed227c5748f16598d16d8631d17dd7e5 \
-    --hash=sha256:40a0b8b2e6f6dd630f8b267eede2f40a848963d0f3c40b1b1f453a4a870f679e \
-    --hash=sha256:40f9a74c7aa210b3e76eb1c9d56aa8d08722b73426a77626967019df9bbac287 \
-    --hash=sha256:423f76aa504c84cb94594fb88b8a24027c887f1c488cf58f2173f22f4fbd046c \
-    --hash=sha256:43bd04cec72281a96eb361e1b0232f0f542b46da50bcfe72ef7e5a1b41d00cb3 \
-    --hash=sha256:43e38762635c09e24885d15e3a8e374b72d105d4178ee2cc9491855a8da9c380 \
-    --hash=sha256:4413b11c2385180d7de03add6c8845dd66692b148d36e27ec8c9ef537b2553a1 \
-    --hash=sha256:4450352a87094fd58daf468b04c65a9fa19ad11a0ac8ac7b7ff17d46f873cbc1 \
-    --hash=sha256:49ffda04a6e44de028b3b786278ac9a70043e7905c3eea29eed88b6524d53a29 \
-    --hash=sha256:4a38c4dde4c9120deef43aaabaa44f19186c98659ce554c29788c4071ab2f0a4 \
-    --hash=sha256:50b1febdfd21e2144b56a9aa226829e93a79c354ef22a4e5b013d9965e1ec0ed \
-    --hash=sha256:559b1a3a8be7395ded2943ea6c2135d096f8cc7039d6d12127110b6496f251fe \
-    --hash=sha256:5de86c182667ec68cf84019aa0d8ceccf01d352cdca19bf9e373725204bdbf50 \
-    --hash=sha256:5fc069bb481fe3fad0ba24d3baaf69e22dfa6cc1b63290e6dfeaf4ac1e996fb7 \
-    --hash=sha256:6a19d654da49516296515d6f65de4bbcbd734bc57913b21a610cfc45e6df3ff1 \
-    --hash=sha256:7535b3e52f498270e7877dde1c8944d6b7720e93e2e66b89c82a11447b5818f5 \
-    --hash=sha256:7c4e495bcabc308198b8962e60ca12f53b27eb8f03a21ac1d2d711d6dd9ecfca \
-    --hash=sha256:8a8fc4a0220367cb8370cedac02272d574079ccc32bffbb34d53aaf9e38b5060 \
-    --hash=sha256:8b008515e067232838daca020d1af628bf6520c8cc338bf383284efe6d8bd083 \
-    --hash=sha256:8d1684258e1385e459418f3429e107eec5fb3d75e1f5a8c52e5946b3f329d6ea \
-    --hash=sha256:8eb5d54b87fb561dc2e00a5c5226c33ffe8dbc13f2e4033a412bafb7b37b194d \
-    --hash=sha256:94cdef0c61bd014bb7af495e21a1c3a369dd0399c3cd1965b1502043f5c88d94 \
-    --hash=sha256:9d9f3be69c7a5e84c3549a8c4403fa9ac7672da456863d21e390b2bbf45ccad1 \
-    --hash=sha256:9fb6fb5975a448169756da2d124a1beb38c0924ff6c0306d883b6848a9980f38 \
-    --hash=sha256:a5eaae8700b87144d7dfb475aa4675e500ff707292caba3deff41609ddc5b845 \
-    --hash=sha256:aaeac2d552772b76d24eaff67a5d2325bc5205c74c0d4f9fbe71685d4a971db2 \
-    --hash=sha256:bb611e447559b3b5665e12a7da5160c0de6876097f62bf1d23ba66911564868e \
-    --hash=sha256:bc0d41f4eb07da8b8d3ea85e50b62f6491ab313834db86ae2345be07536a4e5a \
-    --hash=sha256:bf51051c129b847d1bb63a9b0826346b5f52fb821b15fe5e0d5ef86f268510f5 \
-    --hash=sha256:c948c034d8997526011960db54f512756fb0b4be1b81140a15b4ef094c6594a4 \
-    --hash=sha256:d435a01334157c3b126b4ee5141401d44bdc8440993b18b05e2f267a6647f92d \
-    --hash=sha256:d46c1f95672b73288e08cdca181e14e84c6229b5879561b7b8cfd48374e09287 \
-    --hash=sha256:d5d58309b42064228b16b0311ff715d6c6e20230e81b35e8d0c8cfa1bbdecad8 \
-    --hash=sha256:dc6e2e91365a1dd6314d615d80291159c7981928b88a4c65654e3fefac83a836 \
-    --hash=sha256:e0dfb5f7a39029a6cbec23affa923b22a2c02207960fd66f109e01d6f632c1eb \
-    --hash=sha256:eb4bf58d381b1373bd21d50837a53953d625d1693f1b58fed12743c75d3dd321 \
-    --hash=sha256:ebb211a85248dbc396b29320273c1ffde484b898852432613e8df0164c091006 \
-    --hash=sha256:ec759ece4786ae993a5b7dc3b3dead6e9375d89a6c65dfd6860076d2eb2abe7b \
-    --hash=sha256:f55108397a8fa164268238c3e69cc134e945d1f693572a2f05a028b8d0d2b837 \
-    --hash=sha256:f6c706866d424ff285b85a02de7bbe5ed0ace227766b2c42cbe12f3d9ea5a8aa \
-    --hash=sha256:f8370ad332b36fbad117440faf0dd4b910e80b9c49db5648afd337abdde9a1b6 \
-    # via tensorboard, tensorflow
+grpcio==1.38.0 \
+    --hash=sha256:0247b045feb7b138754c91efcca9ea7f7d2cc9f0bd2cc73f6588c523f38873c3 \
+    --hash=sha256:07abf6b36c138bf247cef7ac0bad9f8ab1c8242f7c1302af23bb8e6877d08163 \
+    --hash=sha256:0ab78d4c16d7f3924718711689f5e301aec52cfcf38eb4143bed0f74b7c4fd10 \
+    --hash=sha256:10a6c62e0cddd456db91f9f04b53a8cccf67d86d7ca814d989423939099c2723 \
+    --hash=sha256:1c11041ecb69d962d49e8a38a35736cdc6fc74230867b5f0ac6138770387a950 \
+    --hash=sha256:1d157a2ac6632d31a3ff21f56bbe73420e1d7a21e4fe89d8c7ac792b79c1a589 \
+    --hash=sha256:1d212af1008bdbfd4b8a287e17a8e63e14d72ac450475307452f20c1bbb6bae4 \
+    --hash=sha256:1e88a8d5d961df958362f61b1b79ad3981a8b051f99224717b09308546298902 \
+    --hash=sha256:25028420d004fe33d64015f5d4d97207c53530acdb493310e217fac76dcd2513 \
+    --hash=sha256:2736b109ec5bd9fcf580bf871b5fd4f136c6ae9728407f344a3c64ad87bb6519 \
+    --hash=sha256:277faad1d8d462bd1b986f43a47a2c2fe795b2e0de72c9318e11826d921e665a \
+    --hash=sha256:291dcde4139bc25629de6a743cfcc0ca861e289e3547421ecd2273b51d95b8e1 \
+    --hash=sha256:2c26cb7566e8942542ff1aee71f10ed35e2f9ee95c2f27179b198af0727fbebb \
+    --hash=sha256:32067791bd56a13614399f1994454afea9e2475019fcabc4abd3112f09892005 \
+    --hash=sha256:34fb08d46a70750bef6566c9556a16b98e08af6345a3bad6574477eb0b08c3dd \
+    --hash=sha256:3cacfee78310b5a89769b2fac20b8cd723470130f5b1ba0c960da8db39e74a97 \
+    --hash=sha256:4a1dd16ccf76ddc18c1cde900049c04ed996e6c02e0588d88d06396c398e6023 \
+    --hash=sha256:604da72df5bece8844a15990ce0b3f2f8c5243a1333d3dcc02371048bf6f9269 \
+    --hash=sha256:6461d69a8ae20e7abce4c6d9cc2603e9f16f4d6b64865eddd0e664127349c04d \
+    --hash=sha256:6824567e2372dde1bd70214427d23b709d09f1a02a552133d1e0f504b616c84e \
+    --hash=sha256:7466eef3b57b5ac8c7585251b26b917b093ab015750bf98aab4e0836c39e2a2b \
+    --hash=sha256:752593a275e26ef250dc4d93a6f7917dd9986396b41eabcc114b0e0315ec1bf6 \
+    --hash=sha256:7b74c48b2e41dd506f889a4a9974d40b3eead965b0fd2e0b1d55a9b3c0e3bc6e \
+    --hash=sha256:897bcd54890e6ec6359063affb35e19a61a58ba37bc61c9e8ac6b464b854233e \
+    --hash=sha256:8c4f39ad529fb4a33cd6e58d1d860c3b583902208547614b4b5b75fc306f13f6 \
+    --hash=sha256:924552099365ea1dd32237dc161849452cd567d931efc57e8427260d8f0eacdb \
+    --hash=sha256:9a2216df1be9fdbc3c1ebd3c5184d1ef4afb387c29224fce00346b9ddec7c7e3 \
+    --hash=sha256:9f1747b81d44daed0649ff10395b58c4f29b03139a628afeb058f3e942ba6893 \
+    --hash=sha256:a0d7c88b4cf9748147cd6c16e14569a124b683a3eb5d7787f43eb9d48cf86755 \
+    --hash=sha256:a4789014f9d9e9ff29551314a004266b1ac90225c8a009dc87947aaf823fd83c \
+    --hash=sha256:a836f21a1d08d28c8344e149b28729649ff4732c318a59a3628451bbd6c3c9ac \
+    --hash=sha256:a8f9fcf5623282e4804595166a4ee1401cf4ccfc16fe84bb69e1eb23ffd836ac \
+    --hash=sha256:abbf9c8c3df4d5233d5888c6cfa85c1bb68a6923749bd4dd1abc6e1e93986f17 \
+    --hash=sha256:ac05434a7a7f444b2ddd109d72f87f4704364be159aea42a04bd6ea2ba6e10e4 \
+    --hash=sha256:b4cd8fb4e3725e8852b1da734904edb3579c76660ae26a72283ac580779e5bf0 \
+    --hash=sha256:b86a1b0654804b5f2248d9262c77a9d5f19882481fc21df53eb2823d0875b86d \
+    --hash=sha256:be83ca2d24321c8bf6516b9cd1064da15ac3ff3978c6c502643be114e2a54af2 \
+    --hash=sha256:c47e85eae34af5d17d1c2007a1f0b13a0293d4b7a6d8c8ae23761d718293803e \
+    --hash=sha256:cbd2754da81bf5f18454c7808b4afe5b57c6736955a742fb599b32b6353fe99f \
+    --hash=sha256:cd220606259f8aa2403bc0f4a4483bae5e36be879364ca3e256f0304ac44f575 \
+    --hash=sha256:d3566acd87a65a0bc93875125a7064293ab2b6ffb9327333030939681d269f4f \
+    --hash=sha256:d631304e66c908d5d2d1a3cc9c02d372d2f8bed8c3632902d6f3f77d7ca34ac2 \
+    --hash=sha256:db01eaea57e7a1898c69271e35a84341cf8150cfdec5f0411eddcfb65b5f590e \
+    --hash=sha256:e3072b9ebb573fe1f6757a55b610e4975979d2d58247cbe18ff4385f5aaa81a5 \
+    --hash=sha256:e72dd202c982a5922c3b846976cae3b699e3fa8d2355d9d5bad119d066cf23ee \
+    --hash=sha256:e83ab148911e6c8ae4ec5e1334e6d800c6b84c432b92eb0ebf0808087117cb39 \
+    --hash=sha256:f19bd4b5bcf88ee059f478c4ab46a1607f09835587750294038fbd0120f1a9dc \
+    --hash=sha256:f2c4ff0e8c98418c5d55c28ba4ff954e3a5d3c723af5008e8d3ddeae8f0ecb41 \
+    --hash=sha256:f6f6d51c9efbfe56af9eb9eeb4881cad1b869e4c0e2a32c1d345897fd0979ee3 \
+    --hash=sha256:f8dd51b05e7fde843d7a3140b058f02801fbec5784a036d5f6abb374450d4608 \
+    --hash=sha256:f9b3678920017842a1b576de3524ecf8f6a2bf4b39f86fb25b870693141e0584
+    # via
+    #   tensorboard
+    #   tensorflow
 h5py==2.9.0 \
     --hash=sha256:05750b91640273c69989c657eaac34b091abdd75efc8c4824c82aaf898a2da0a \
     --hash=sha256:082a27208aa3a2286e7272e998e7e225b2a7d4b7821bd840aebf96d50977abbb \
@@ -221,61 +224,58 @@ h5py==2.9.0 \
     --hash=sha256:c5dd4ec75985b99166c045909e10f0534704d102848b1d9f0992720e908928e7 \
     --hash=sha256:d2b82f23cd862a9d05108fe99967e9edfa95c136f532a71cb3d28dc252771f50 \
     --hash=sha256:e58a25764472af07b7e1c4b10b0179c8ea726446c7141076286e41891bf3a563 \
-    --hash=sha256:f3b49107fbfc77333fc2b1ef4d5de2abcd57e7ea3a1482455229494cf2da56ce \
-    # via keras, keras-applications
-holidays==0.9.11 \
-    --hash=sha256:915fdb92b596cfb66067010759b4384a9c6bc82931311d5bf07fe04920cc11bc \
-    # via fbprophet
-idna==2.8 \
-    --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
-    --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c \
+    --hash=sha256:f3b49107fbfc77333fc2b1ef4d5de2abcd57e7ea3a1482455229494cf2da56ce
+    # via
+    #   keras
+    #   keras-applications
+idna==2.10 \
+    --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
+    --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
     # via requests
 importlib-metadata==0.23 \
     --hash=sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26 \
-    --hash=sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af \
-    # via jsonschema
+    --hash=sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af
+    # via markdown
 ipython-genutils==0.2.0 \
     --hash=sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8 \
-    --hash=sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8 \
+    --hash=sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8
     # via traitlets
 ipython==7.5.0 \
     --hash=sha256:54c5a8aa1eadd269ac210b96923688ccf01ebb2d0f21c18c3c717909583579a8 \
-    --hash=sha256:e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26 \
+    --hash=sha256:e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26
     # via nb-black
 jax==0.1.55 \
-    --hash=sha256:5531d5bea2936ac9098e8057ff0e9ed9ddba3e72a3a7813a09f8bfa84ba90f5a \
+    --hash=sha256:5531d5bea2936ac9098e8057ff0e9ed9ddba3e72a3a7813a09f8bfa84ba90f5a
     # via -r requirements.in
 jedi==0.13.3 \
     --hash=sha256:2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b \
-    --hash=sha256:2c6bcd9545c7d6440951b12b44d373479bf18123a401a52025cf98563fbd826c \
+    --hash=sha256:2c6bcd9545c7d6440951b12b44d373479bf18123a401a52025cf98563fbd826c
     # via ipython
-jinja2==2.10.3 \
-    --hash=sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f \
-    --hash=sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de \
-    # via altair
 jmespath==0.9.4 \
     --hash=sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6 \
-    --hash=sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c \
-    # via boto3, botocore
+    --hash=sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c
+    # via
+    #   boto3
+    #   botocore
 joblib==0.14.0 \
     --hash=sha256:006108c7576b3eb6c5b27761ddbf188eb6e6347696325ab2027ea1ee9a4b922d \
-    --hash=sha256:6fcc57aacb4e89451fd449e9412687c51817c3f48662c3d8f38ba3f8a0a193ff \
+    --hash=sha256:6fcc57aacb4e89451fd449e9412687c51817c3f48662c3d8f38ba3f8a0a193ff
     # via scikit-learn
-jsonschema==3.2.0 \
-    --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
-    --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a \
-    # via altair
 keras-applications==1.0.8 \
     --hash=sha256:5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5 \
-    --hash=sha256:df4323692b8c1174af821bf906f1e442e63fa7589bf0f1230a0b6bdc5a810c95 \
-    # via keras, tensorflow
-keras-preprocessing==1.0.9 \
-    --hash=sha256:0170b799a7562f80ad7931d22d56de22cf4bdd502e11c48f31a46380137a70a8 \
-    --hash=sha256:5e3700117981c2db762e512ed6586638124fac5842170701628088a11aeb51ac \
-    # via keras, tensorflow
+    --hash=sha256:df4323692b8c1174af821bf906f1e442e63fa7589bf0f1230a0b6bdc5a810c95
+    # via
+    #   keras
+    #   tensorflow
+keras-preprocessing==1.1.2 \
+    --hash=sha256:7b82029b130ff61cc99b55f3bd27427df4838576838c5b2f65940e4fcec99a7b \
+    --hash=sha256:add82567c50c8bc648c14195bf544a5ce7c1f76761536956c3d2978970179ef3
+    # via
+    #   keras
+    #   tensorflow
 keras==2.3.1 \
     --hash=sha256:321d43772006a25a1d58eea17401ef2a34d388b588c9f7646c34796151ebc8cc \
-    --hash=sha256:d08a57bd63546175f8f19232ba05906514d419da3e0af8ef7437fa1c11442e20 \
+    --hash=sha256:d08a57bd63546175f8f19232ba05906514d419da3e0af8ef7437fa1c11442e20
     # via -r requirements.in
 kiwisolver==1.1.0 \
     --hash=sha256:05b5b061e09f60f56244adc885c4a7867da25ca387376b02c1efc29cc16bcd0f \
@@ -314,47 +314,12 @@ kiwisolver==1.1.0 \
     --hash=sha256:f16814a4a96dc04bf1da7d53ee8d5b1d6decfc1a92a63349bb15d37b6a263dd9 \
     --hash=sha256:f2b22153870ca5cf2ab9c940d7bc38e8e9089fa0f7e5856ea195e1cf4ff43d5a \
     --hash=sha256:f790f8b3dff3d53453de6a7b7ddd173d2e020fb160baff578d578065b108a05f \
-    --hash=sha256:fe51b79da0062f8e9d49ed0182a626a7dc7a0cbca0328f612c6ee5e4711c81e4 \
+    --hash=sha256:fe51b79da0062f8e9d49ed0182a626a7dc7a0cbca0328f612c6ee5e4711c81e4
     # via matplotlib
-lunardate==0.2.0 \
-    --hash=sha256:5619d625809ebcaa673c4e321cd1ea82e649e9bb47e42e6479fe15bbc2b5bffe \
-    --hash=sha256:6c9c96d9f01522a10ab35df1a9b48707ae64a086f13fd34498b43f465918cc6f \
-    --hash=sha256:838e84b95d185a12f8bd0c5bdd74864be52d55436bed56927fdc91f4d21ad6b6 \
-    # via fbprophet
-markdown==3.1 \
-    --hash=sha256:fc4a6f69a656b8d858d7503bda633f4dd63c2d70cf80abdc6eafa64c4ae8c250 \
-    --hash=sha256:fe463ff51e679377e3624984c829022e2cfb3be5518726b06f608a07a3aad680 \
+markdown==3.3.4 \
+    --hash=sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49 \
+    --hash=sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c
     # via tensorboard
-markupsafe==1.1.1 \
-    --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
-    --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
-    --hash=sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235 \
-    --hash=sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5 \
-    --hash=sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff \
-    --hash=sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b \
-    --hash=sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1 \
-    --hash=sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e \
-    --hash=sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183 \
-    --hash=sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66 \
-    --hash=sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1 \
-    --hash=sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1 \
-    --hash=sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e \
-    --hash=sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b \
-    --hash=sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905 \
-    --hash=sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735 \
-    --hash=sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d \
-    --hash=sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e \
-    --hash=sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d \
-    --hash=sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c \
-    --hash=sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21 \
-    --hash=sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2 \
-    --hash=sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5 \
-    --hash=sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b \
-    --hash=sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6 \
-    --hash=sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f \
-    --hash=sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f \
-    --hash=sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7 \
-    # via jinja2
 matplotlib==3.1.2 \
     --hash=sha256:08ccc8922eb4792b91c652d3e6d46b1c99073f1284d1b6705155643e8046463a \
     --hash=sha256:161dcd807c0c3232f4dcd4a12a382d52004a498174cbfafd40646106c5bcdcc8 \
@@ -368,11 +333,13 @@ matplotlib==3.1.2 \
     --hash=sha256:8e8e2c2fe3d873108735c6ee9884e6f36f467df4a143136209cff303b183bada \
     --hash=sha256:98c2ffeab8b79a4e3a0af5dd9939f92980eb6e3fec10f7f313df5f35a84dacab \
     --hash=sha256:d59bb0e82002ac49f4152963f8a1079e66794a4f454457fd2f0dcc7bf0797d30 \
-    --hash=sha256:ee59b7bb9eb75932fe3787e54e61c99b628155b0cedc907864f24723ba55b309 \
-    # via -r requirements.in, fbprophet, seaborn
+    --hash=sha256:ee59b7bb9eb75932fe3787e54e61c99b628155b0cedc907864f24723ba55b309
+    # via
+    #   -r requirements.in
+    #   seaborn
 more-itertools==7.2.0 \
     --hash=sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832 \
-    --hash=sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4 \
+    --hash=sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4
     # via zipp
 mysql-connector-python==8.0.18 \
     --hash=sha256:033a8ab1d772ce77ce6cbbaca5bff400bfb65a2a3542b701061c981222a0fefd \
@@ -397,10 +364,10 @@ mysql-connector-python==8.0.18 \
     --hash=sha256:a956b77c9c73bff6e17f068fbd8d03c3631a2ef974703f784f8dbfa348c983ec \
     --hash=sha256:ac4474bf836be6696e4930884725b9de33df4d246fb433255126fb007cb8a59e \
     --hash=sha256:acbaf0c87b1398d238f0fe77af18feefc8b6c3569e7fe96307bca3ed3f0eb240 \
-    --hash=sha256:c3d2dbd81e78d8d2cd1504483daf930219e623b3b9f269a2c2b3bad79a031fa5 \
+    --hash=sha256:c3d2dbd81e78d8d2cd1504483daf930219e623b3b9f269a2c2b3bad79a031fa5
     # via -r requirements.in
 nb_black==1.0.6 \
-    --hash=sha256:c6dadc150e216758e4d017614c733f0f56ff99e3a64bcd0335494ecf5ee7580b \
+    --hash=sha256:c6dadc150e216758e4d017614c733f0f56ff99e3a64bcd0335494ecf5ee7580b
     # via -r requirements.in
 numpy==1.17.4 \
     --hash=sha256:0a7a1dd123aecc9f0076934288ceed7fd9a81ba3919f11a855a7887cbe82a02f \
@@ -423,15 +390,33 @@ numpy==1.17.4 \
     --hash=sha256:e467c57121fe1b78a8f68dd9255fbb3bb3f4f7547c6b9e109f31d14569f490c3 \
     --hash=sha256:ede47b98de79565fcd7f2decb475e2dcc85ee4097743e551fe26cfc7eb3ff143 \
     --hash=sha256:f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316 \
-    --hash=sha256:fe39f5fd4103ec4ca3cb8600b19216cd1ff316b4990f4c0b6057ad982c0a34d5 \
-    # via -r requirements.in, altair, fbprophet, h5py, jax, keras, keras-applications, keras-preprocessing, matplotlib, opt-einsum, pandas, pystan, scikit-learn, scipy, seaborn, tensorboard, tensorflow, tensorflow-probability
+    --hash=sha256:fe39f5fd4103ec4ca3cb8600b19216cd1ff316b4990f4c0b6057ad982c0a34d5
+    # via
+    #   -r requirements.in
+    #   h5py
+    #   jax
+    #   keras
+    #   keras-applications
+    #   keras-preprocessing
+    #   matplotlib
+    #   opt-einsum
+    #   pandas
+    #   pystan
+    #   scikit-learn
+    #   scipy
+    #   seaborn
+    #   tensorboard
+    #   tensorflow
+    #   tensorflow-probability
 oauthlib==3.1.0 \
     --hash=sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889 \
-    --hash=sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea \
+    --hash=sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea
     # via requests-oauthlib
 opt-einsum==3.1.0 \
-    --hash=sha256:edfada4b1d0b3b782ace8bc14e80618ff629abf53143e1e6bbf9bd00b11ece77 \
-    # via jax, tensorflow
+    --hash=sha256:edfada4b1d0b3b782ace8bc14e80618ff629abf53143e1e6bbf9bd00b11ece77
+    # via
+    #   jax
+    #   tensorflow
 pandas==0.25.3 \
     --hash=sha256:00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d \
     --hash=sha256:22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e \
@@ -451,77 +436,83 @@ pandas==0.25.3 \
     --hash=sha256:bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf \
     --hash=sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133 \
     --hash=sha256:e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7 \
-    --hash=sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c \
-    # via -r requirements.in, altair, fbprophet, seaborn
+    --hash=sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c
+    # via
+    #   -r requirements.in
+    #   seaborn
 parso==0.4.0 \
     --hash=sha256:17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33 \
-    --hash=sha256:2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376 \
+    --hash=sha256:2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376
     # via jedi
 pathspec==0.6.0 \
-    --hash=sha256:e285ccc8b0785beadd4c18e5708b12bb8fcf529a1e61215b3feff1d1e559ea5c \
+    --hash=sha256:e285ccc8b0785beadd4c18e5708b12bb8fcf529a1e61215b3feff1d1e559ea5c
     # via black
 pexpect==4.7.0 \
     --hash=sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1 \
-    --hash=sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb \
+    --hash=sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb
     # via ipython
 pickleshare==0.7.5 \
     --hash=sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca \
-    --hash=sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56 \
+    --hash=sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56
     # via ipython
 prompt-toolkit==2.0.9 \
     --hash=sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780 \
     --hash=sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1 \
-    --hash=sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55 \
+    --hash=sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55
     # via ipython
-protobuf==3.7.1 \
-    --hash=sha256:21e395d7959551e759d604940a115c51c6347d90a475c9baf471a1a86b5604a9 \
-    --hash=sha256:57e05e16955aee9e6a0389fcbd58d8289dd2420e47df1a1096b3a232c26eb2dd \
-    --hash=sha256:67819e8e48a74c68d87f25cad9f40edfe2faf278cdba5ca73173211b9213b8c9 \
-    --hash=sha256:75da7d43a2c8a13b0bc7238ab3c8ae217cbfd5979d33b01e98e1f78defb2d060 \
-    --hash=sha256:78e08371e236f193ce947712c072542ff19d0043ab5318c2ea46bbc2aaebdca6 \
-    --hash=sha256:7ee5b595db5abb0096e8c4755e69c20dfad38b2d0bcc9bc7bafc652d2496b471 \
-    --hash=sha256:86260ecfe7a66c0e9d82d2c61f86a14aa974d340d159b829b26f35f710f615db \
-    --hash=sha256:92c77db4bd33ea4ee5f15152a835273f2338a5246b2cbb84bab5d0d7f6e9ba94 \
-    --hash=sha256:9c7b90943e0e188394b4f068926a759e3b4f63738190d1ab3d500d53b9ce7614 \
-    --hash=sha256:a77f217ea50b2542bae5b318f7acee50d9fc8c95dd6d3656eaeff646f7cab5ee \
-    --hash=sha256:ad589ed1d1f83db22df867b10e01fe445516a5a4d7cfa37fe3590a5f6cfc508b \
-    --hash=sha256:b06a794901bf573f4b2af87e6139e5cd36ac7c91ac85d7ae3fe5b5f6fc317513 \
-    --hash=sha256:bd8592cc5f8b4371d0bad92543370d4658dc41a5ccaaf105597eb5524c616291 \
-    --hash=sha256:be48e5a6248a928ec43adf2bea037073e5da692c0b3c10b34f9904793bd63138 \
-    --hash=sha256:cc5eb13f5ccc4b1b642cc147c2cdd121a34278b341c7a4d79e91182fff425836 \
-    --hash=sha256:cd3b0e0ad69b74ee55e7c321f52a98effed2b4f4cc9a10f3683d869de00590d5 \
-    --hash=sha256:d6e88c4920660aa75c0c2c4b53407aef5efd9a6e0ca7d2fc84d79aba2ccbda3a \
-    --hash=sha256:ec3c49b6d247152e19110c3a53d9bb4cf917747882017f70796460728b02722e \
-    # via mysql-connector-python, tensorboard, tensorflow
+protobuf==3.17.1 \
+    --hash=sha256:0f237c1e84e46747397a3e8173edb3116e81163b2878fc944a5193b05876eaee \
+    --hash=sha256:1fcace96670b8512e805d6e275bd59b860967a7648e05cfad35ec1e7c03d7262 \
+    --hash=sha256:25bc4f1c23aced9b3a9e70eef7f03e63bcbd6cfbd881a91b5688412dce8992e1 \
+    --hash=sha256:27c7c933b838a0837eb1f429e7994310ee8577a7b69abc38e84d5db97a2650a2 \
+    --hash=sha256:2a88be54fce118d69f083b847554afd1852053c0869bdac396678ec9ec6a94d5 \
+    --hash=sha256:2c6ad26f079301bcf9f1b5d5b4b2dbac0e2e7c0111c6fbecf94f558952c78ee0 \
+    --hash=sha256:36d306dda3c159a5fe0025ba0e9728aac00dd69523dd12ee3fb7b1717cd80e7d \
+    --hash=sha256:40bf764b63f06a816b1c079f7718184fdd8dbfd9dad3cd1a446382492ca00b3e \
+    --hash=sha256:437d4681160ac5310457c4dc8ab973ec56769a236c479393c53fa71a26dfb38f \
+    --hash=sha256:4ef4865ee740d5b45adfc96481adf1fcbfbb454bd51b86f4c4a5065262d0b08b \
+    --hash=sha256:5057744a363d65d2780dc01fa751bb14e860c507b2598b22af241aabb28a0ae9 \
+    --hash=sha256:6e48c9b26d8e262331c79b208c4bf6b499a71912b1213d77b63c5ca248fc2a4e \
+    --hash=sha256:762faa8873d0569466cf66128bdbadd5e500600bdf2f87cf039493ed9d2725b6 \
+    --hash=sha256:8a509097ba25452c9b44198843b0df67f921bd36f37adcbcfaaf6ee5cbe09132 \
+    --hash=sha256:94be4d5c2ba372ff159b2cc804d274acbaa7ebf361966f5619f99880c7c09a3c \
+    --hash=sha256:a15898d88307dba0363767b30960396a2dec74b8ffe7bcb4e885312a569eda3f \
+    --hash=sha256:ad17d3dd80f3377fc70a9dd677ec51231a892f9f65783cf7d2d24ee381f0feca \
+    --hash=sha256:ad8cdbc594c886483970ac274b5af98483b272e873b7c5dac60aa3a7222301b3 \
+    --hash=sha256:b92f95994ff27a6992ea2cf3f369476ad0065986eb00252b760d0bc55c5454a8 \
+    --hash=sha256:c1631570af7aae611f1cd7c6918fe4a7154507169ef30e8c5f380eba36ee2659 \
+    --hash=sha256:cbd132f0aa7180f099d3c47fecfbcdca1590ef3b7da8346146192ba580c9b24e \
+    --hash=sha256:d06ef0f7873e04e2d1a2bfa0701d063e4dde5242b2946c6f071a442e4cb3be0b \
+    --hash=sha256:fea786428b34385b073ef619d896282889b432b87dc043c0b815c72d35d64025
+    # via
+    #   mysql-connector-python
+    #   tensorboard
+    #   tensorflow
 ptyprocess==0.6.0 \
     --hash=sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0 \
-    --hash=sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f \
+    --hash=sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f
     # via pexpect
-pyasn1-modules==0.2.7 \
-    --hash=sha256:0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b \
-    --hash=sha256:b6ada4f840fe51abf5a6bd545b45bf537bea62221fa0dde2e8a553ed9f06a4e3 \
+pyasn1-modules==0.2.8 \
+    --hash=sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e \
+    --hash=sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74
     # via google-auth
 pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
-    --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba \
-    # via pyasn1-modules, rsa
+    --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
+    # via
+    #   pyasn1-modules
+    #   rsa
 pyathena==1.9.0 \
-    --hash=sha256:7298161243d2c99f1110c8c3dc34c5e6aa25b96fc9a4a6889d4773ee7871d44e \
+    --hash=sha256:7298161243d2c99f1110c8c3dc34c5e6aa25b96fc9a4a6889d4773ee7871d44e
     # via -r requirements.in
 pygments==2.3.1 \
     --hash=sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a \
-    --hash=sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d \
+    --hash=sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d
     # via ipython
-pymeeus==0.3.6 \
-    --hash=sha256:1f1ba0682e1b5c6b0cd6432c966e8bc8acc31737ea6f0ae79917a2189a98bb87 \
-    # via convertdate
 pyparsing==2.4.0 \
     --hash=sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a \
-    --hash=sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03 \
+    --hash=sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03
     # via matplotlib
-pyrsistent==0.15.6 \
-    --hash=sha256:f3b280d030afb652f79d67c5586157c5c1355c9a58dfc7940566e28d28f3df1b \
-    # via jsonschema
 pystan==2.19.1.1 \
     --hash=sha256:1127522641533a6ccb7684d4008d06c092cbe6f3ee7d44679a87937ee39093ab \
     --hash=sha256:2b44502aaa8866e0bcc81df1537e7e08b74aaf4cc9d4bf43e7c8b168f3568ca6 \
@@ -538,16 +529,19 @@ pystan==2.19.1.1 \
     --hash=sha256:c87bd98db2b5c67fa08177de04c98b46d1fcd68ae53dbe55ffc5187868068002 \
     --hash=sha256:e6580cec2f5ed1bdb44eab83d54fe87b11e673ed65d6c2064d8d9f76265ce049 \
     --hash=sha256:e9fbbf10dfc0ef8e7343ee4a3e17fd5c214fb12fc42615673e14908949b410e4 \
-    --hash=sha256:fa8bad8dbc0da22bbe6f36af56c9abbfcf10f92df8ce627d59a36bd8d25eb038 \
-    # via -r requirements.in, fbprophet
+    --hash=sha256:fa8bad8dbc0da22bbe6f36af56c9abbfcf10f92df8ce627d59a36bd8d25eb038
+    # via -r requirements.in
 python-dateutil==2.8.0 \
     --hash=sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb \
-    --hash=sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e \
-    # via botocore, holidays, matplotlib, pandas
+    --hash=sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e
+    # via
+    #   botocore
+    #   matplotlib
+    #   pandas
 pytz==2019.1 \
     --hash=sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda \
-    --hash=sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141 \
-    # via convertdate, pandas
+    --hash=sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141
+    # via pandas
 pyyaml==5.1 \
     --hash=sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c \
     --hash=sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95 \
@@ -559,7 +553,7 @@ pyyaml==5.1 \
     --hash=sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e \
     --hash=sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673 \
     --hash=sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13 \
-    --hash=sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19 \
+    --hash=sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19
     # via keras
 regex==2019.11.1 \
     --hash=sha256:15454b37c5a278f46f7aa2d9339bda450c300617ca2fca6558d05d870245edc7 \
@@ -574,23 +568,25 @@ regex==2019.11.1 \
     --hash=sha256:c7393597191fc2043c744db021643549061e12abe0b3ff5c429d806de7b93b66 \
     --hash=sha256:d2b302f8cdd82c8f48e9de749d1d17f85ce9a0f082880b9a4859f66b07037dc6 \
     --hash=sha256:e3d8dd0ec0ea280cf89026b0898971f5750a7bd92cb62c51af5a52abd020054a \
-    --hash=sha256:ec032cbfed59bd5a4b8eab943c310acfaaa81394e14f44454ad5c9eba4f24a74 \
+    --hash=sha256:ec032cbfed59bd5a4b8eab943c310acfaaa81394e14f44454ad5c9eba4f24a74
     # via black
 requests-oauthlib==1.3.0 \
     --hash=sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d \
-    --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a \
+    --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a
     # via google-auth-oauthlib
-requests==2.22.0 \
-    --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
-    --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31 \
-    # via requests-oauthlib
-rsa==4.0 \
-    --hash=sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66 \
-    --hash=sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487 \
+requests==2.25.1 \
+    --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
+    --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
+    # via
+    #   requests-oauthlib
+    #   tensorboard
+rsa==4.7.2 \
+    --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
+    --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
     # via google-auth
 s3transfer==0.2.1 \
     --hash=sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d \
-    --hash=sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba \
+    --hash=sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba
     # via boto3
 scikit-learn==0.21.3 \
     --hash=sha256:1ac81293d261747c25ea5a0ee8cd2bb1f3b5ba9ec05421a7f9f0feb4eb7c4116 \
@@ -608,60 +604,69 @@ scikit-learn==0.21.3 \
     --hash=sha256:d07fcb0c0acbc043faa0e7cf4d2037f71193de3fb04fb8ed5c259b089af1cf5c \
     --hash=sha256:d146d5443cda0a41f74276e42faf8c7f283fef49e8a853b832885239ef544e05 \
     --hash=sha256:eb2b7bed0a26ba5ce3700e15938b28a4f4513578d3e54a2156c29df19ac5fd01 \
-    --hash=sha256:eb9b8ebf59eddd8b96366428238ab27d05a19e89c5516ce294abc35cea75d003 \
+    --hash=sha256:eb9b8ebf59eddd8b96366428238ab27d05a19e89c5516ce294abc35cea75d003
     # via -r requirements.in
-scipy==1.2.1 \
-    --hash=sha256:014cb900c003b5ac81a53f2403294e8ecf37aedc315b59a6b9370dce0aa7627a \
-    --hash=sha256:281a34da34a5e0de42d26aed692ab710141cad9d5d218b20643a9cb538ace976 \
-    --hash=sha256:588f9cc4bfab04c45fbd19c1354b5ade377a8124d6151d511c83730a9b6b2338 \
-    --hash=sha256:5a10661accd36b6e2e8855addcf3d675d6222006a15795420a39c040362def66 \
-    --hash=sha256:628f60be272512ca1123524969649a8cb5ae8b31cca349f7c6f8903daf9034d7 \
-    --hash=sha256:6dcc43a88e25b815c2dea1c6fac7339779fc988f5df8396e1de01610604a7c38 \
-    --hash=sha256:70e37cec0ac0fe95c85b74ca4e0620169590fd5d3f44765f3c3a532cedb0e5fd \
-    --hash=sha256:7274735fb6fb5d67d3789ddec2cd53ed6362539b41aa6cc0d33a06c003aaa390 \
-    --hash=sha256:78e12972e144da47326958ac40c2bd1c1cca908edc8b01c26a36f9ffd3dce466 \
-    --hash=sha256:790cbd3c8d09f3a6d9c47c4558841e25bac34eb7a0864a9def8f26be0b8706af \
-    --hash=sha256:79792c8fe8e9d06ebc50fe23266522c8c89f20aa94ac8e80472917ecdce1e5ba \
-    --hash=sha256:865afedf35aaef6df6344bee0de391ee5e99d6e802950a237f9fb9b13e441f91 \
-    --hash=sha256:870fd401ec7b64a895cff8e206ee16569158db00254b2f7157b4c9a5db72c722 \
-    --hash=sha256:963815c226b29b0176d5e3d37fc9de46e2778ce4636a5a7af11a48122ef2577c \
-    --hash=sha256:9726791484f08e394af0b59eb80489ad94d0a53bbb58ab1837dcad4d58489863 \
-    --hash=sha256:9de84a71bb7979aa8c089c4fb0ea0e2ed3917df3fb2a287a41aaea54bbad7f5d \
-    --hash=sha256:b2c324ddc5d6dbd3f13680ad16a29425841876a84a1de23a984236d1afff4fa6 \
-    --hash=sha256:b86ae13c597fca087cb8c193870507c8916cefb21e52e1897da320b5a35075e5 \
-    --hash=sha256:ba0488d4dbba2af5bf9596b849873102d612e49a118c512d9d302ceafa36e01a \
-    --hash=sha256:d78702af4102a3a4e23bb7372cec283e78f32f5573d92091aa6aaba870370fe1 \
-    --hash=sha256:def0e5d681dd3eb562b059d355ae8bebe27f5cc455ab7c2b6655586b63d3a8ea \
-    --hash=sha256:e085d1babcb419bbe58e2e805ac61924dac4ca45a07c9fa081144739e500aa3c \
-    --hash=sha256:e2cfcbab37c082a5087aba5ff00209999053260441caadd4f0e8f4c2d6b72088 \
-    --hash=sha256:e742f1f5dcaf222e8471c37ee3d1fd561568a16bb52e031c25674ff1cf9702d5 \
-    --hash=sha256:f06819b028b8ef9010281e74c59cb35483933583043091ed6b261bb1540f11cc \
-    --hash=sha256:f15f2d60a11c306de7700ee9f65df7e9e463848dbea9c8051e293b704038da60 \
-    --hash=sha256:f31338ee269d201abe76083a990905473987371ff6f3fdb76a3f9073a361cf37 \
-    --hash=sha256:f6b88c8d302c3dac8dff7766955e38d670c82e0d79edfc7eae47d6bb2c186594 \
-    # via keras, scikit-learn, seaborn
+scipy==1.4.1 \
+    --hash=sha256:00af72998a46c25bdb5824d2b729e7dabec0c765f9deb0b504f928591f5ff9d4 \
+    --hash=sha256:0902a620a381f101e184a958459b36d3ee50f5effd186db76e131cbefcbb96f7 \
+    --hash=sha256:1e3190466d669d658233e8a583b854f6386dd62d655539b77b3fa25bfb2abb70 \
+    --hash=sha256:2cce3f9847a1a51019e8c5b47620da93950e58ebc611f13e0d11f4980ca5fecb \
+    --hash=sha256:3092857f36b690a321a662fe5496cb816a7f4eecd875e1d36793d92d3f884073 \
+    --hash=sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa \
+    --hash=sha256:71eb180f22c49066f25d6df16f8709f215723317cc951d99e54dc88020ea57be \
+    --hash=sha256:770254a280d741dd3436919d47e35712fb081a6ff8bafc0f319382b954b77802 \
+    --hash=sha256:787cc50cab3020a865640aba3485e9fbd161d4d3b0d03a967df1a2881320512d \
+    --hash=sha256:8a07760d5c7f3a92e440ad3aedcc98891e915ce857664282ae3c0220f3301eb6 \
+    --hash=sha256:8d3bc3993b8e4be7eade6dcc6fd59a412d96d3a33fa42b0fa45dc9e24495ede9 \
+    --hash=sha256:9508a7c628a165c2c835f2497837bf6ac80eb25291055f56c129df3c943cbaf8 \
+    --hash=sha256:a144811318853a23d32a07bc7fd5561ff0cac5da643d96ed94a4ffe967d89672 \
+    --hash=sha256:a1aae70d52d0b074d8121333bc807a485f9f1e6a69742010b33780df2e60cfe0 \
+    --hash=sha256:a2d6df9eb074af7f08866598e4ef068a2b310d98f87dc23bd1b90ec7bdcec802 \
+    --hash=sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408 \
+    --hash=sha256:c5cac0c0387272ee0e789e94a570ac51deb01c796b37fb2aad1fb13f85e2f97d \
+    --hash=sha256:cc971a82ea1170e677443108703a2ec9ff0f70752258d0e9f5433d00dda01f59 \
+    --hash=sha256:dba8306f6da99e37ea08c08fef6e274b5bf8567bb094d1dbe86a20e532aca088 \
+    --hash=sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521 \
+    --hash=sha256:dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59
+    # via
+    #   keras
+    #   scikit-learn
+    #   seaborn
 seaborn==0.9.0 \
     --hash=sha256:42e627b24e849c2d3bbfd059e00005f6afbc4a76e4895baf44ae23fe8a4b09a5 \
-    --hash=sha256:76c83f794ca320fb6b23a7c6192d5e185a5fcf4758966a0c0a54baee46d41e2f \
+    --hash=sha256:76c83f794ca320fb6b23a7c6192d5e185a5fcf4758966a0c0a54baee46d41e2f
     # via -r requirements.in
-setuptools-git==1.2 \
-    --hash=sha256:e7764dccce7d97b4b5a330d7b966aac6f9ac026385743fd6cedad553f2494cfa \
-    --hash=sha256:ff64136da01aabba76ae88b050e7197918d8b2139ccbf6144e14d472b9c40445 \
-    # via fbprophet
 six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
-    --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
-    # via absl-py, altair, cycler, google-auth, google-pasta, grpcio, h5py, holidays, jax, jsonschema, keras, keras-preprocessing, prompt-toolkit, protobuf, pyrsistent, python-dateutil, tenacity, tensorboard, tensorflow, tensorflow-probability, traitlets
+    --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
+    # via
+    #   absl-py
+    #   cycler
+    #   google-auth
+    #   google-pasta
+    #   grpcio
+    #   h5py
+    #   jax
+    #   keras
+    #   keras-preprocessing
+    #   prompt-toolkit
+    #   protobuf
+    #   python-dateutil
+    #   tenacity
+    #   tensorboard
+    #   tensorflow
+    #   tensorflow-probability
+    #   traitlets
 tenacity==6.0.0 \
     --hash=sha256:72f397c2bb1887e048726603f3f629ea16f88cb3e61e4ed3c57e98582b8e3571 \
-    --hash=sha256:947e728aedf06e8db665bb7898112e90d17e48cc3f3289784a2b9ccf6e56fabc \
+    --hash=sha256:947e728aedf06e8db665bb7898112e90d17e48cc3f3289784a2b9ccf6e56fabc
     # via pyathena
-tensorboard==2.0.1 \
-    --hash=sha256:203bd0c2fa33e18c009fa21253b67b67b78ef9624c4df3f70d3ef1b4f0ca3f9c \
-    --hash=sha256:bf66fc182fcbfff6fc2e770754a100ef5c6bdc8601fece92375f31da60733fdc \
+tensorboard==2.0.2 \
+    --hash=sha256:32d9dec38d053d7d75796eb7c2e0d77285af35f69ee1a6796ab5ecc896679fb3 \
+    --hash=sha256:ccae56f01acc78a138474081b631af52017c2075ffe1c453d58c49d5046ef081
     # via tensorflow
 tensorflow-estimator==2.0.1 \
-    --hash=sha256:aa8deab25d09a9730dfbae8ec58f4eb00ec2a90b5ca3dcbd8fa0717103d3bbb3 \
+    --hash=sha256:aa8deab25d09a9730dfbae8ec58f4eb00ec2a90b5ca3dcbd8fa0717103d3bbb3
     # via tensorflow
 tensorflow==2.0.0 \
     --hash=sha256:1351cc812880b083acf243602d05036bb27711ca66ee08c99a2d16da70371906 \
@@ -674,28 +679,25 @@ tensorflow==2.0.0 \
     --hash=sha256:e7f1c217852facad332e59025d4f872df0ba8fef0322249af4db98ffe09e9f41 \
     --hash=sha256:f132935755472b77c1bf6d638f32c3101e5d6c04c5d6725dff8b6e27c5f9e15a \
     --hash=sha256:f31357637ae6dcdf135b4fd108f325bd6399d250cc2eefefd65140d5313fdd3a \
-    --hash=sha256:fca6a935bb96f947c28a4bebba7ca1d8b9686fb4c02a06d24b11a2f66ca20b81 \
+    --hash=sha256:fca6a935bb96f947c28a4bebba7ca1d8b9686fb4c02a06d24b11a2f66ca20b81
     # via -r requirements.in
 tensorflow_probability==0.8.0 \
-    --hash=sha256:91502b41753a48bc28f8ded2b25d1931135be87c343d93da47cb446ee05ad468 \
+    --hash=sha256:91502b41753a48bc28f8ded2b25d1931135be87c343d93da47cb446ee05ad468
     # via -r requirements.in
 termcolor==1.1.0 \
-    --hash=sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b \
+    --hash=sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b
     # via tensorflow
 toml==0.10.0 \
     --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
-    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e
     # via black
-toolz==0.10.0 \
-    --hash=sha256:08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560 \
-    # via altair
 tqdm==4.39.0 \
     --hash=sha256:5a1f3d58f3eb53264387394387fe23df469d2a3fab98c9e7f99d5c146c119873 \
-    --hash=sha256:f1a1613fee07cc30a253051617f2a219a785c58877f9f6bfa129446cbaf8b4c1 \
+    --hash=sha256:f1a1613fee07cc30a253051617f2a219a785c58877f9f6bfa129446cbaf8b4c1
     # via -r requirements.in
 traitlets==4.3.2 \
     --hash=sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835 \
-    --hash=sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9 \
+    --hash=sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9
     # via ipython
 typed-ast==1.4.0 \
     --hash=sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161 \
@@ -717,34 +719,45 @@ typed-ast==1.4.0 \
     --hash=sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d \
     --hash=sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a \
     --hash=sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66 \
-    --hash=sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12 \
+    --hash=sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12
     # via black
 urllib3==1.25.7 \
     --hash=sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293 \
-    --hash=sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745 \
-    # via botocore, requests
+    --hash=sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745
+    # via
+    #   botocore
+    #   requests
 wcwidth==0.1.7 \
     --hash=sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e \
-    --hash=sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c \
+    --hash=sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c
     # via prompt-toolkit
 werkzeug==0.16.0 \
     --hash=sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7 \
-    --hash=sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4 \
-    # via -r requirements.in, tensorboard
-wheel==0.33.1 \
-    --hash=sha256:66a8fd76f28977bb664b098372daef2b27f60dc4d1688cfab7b37a09448f0e9d \
-    --hash=sha256:8eb4a788b3aec8abf5ff68d4165441bc57420c9f64ca5f471f58c3969fe08668 \
-    # via tensorboard, tensorflow
-wrapt==1.11.2 \
-    --hash=sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1 \
+    --hash=sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4
+    # via
+    #   -r requirements.in
+    #   tensorboard
+wheel==0.36.2 \
+    --hash=sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e \
+    --hash=sha256:e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e
+    # via
+    #   tensorboard
+    #   tensorflow
+wrapt==1.12.1 \
+    --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
     # via tensorflow
 zipp==0.6.0 \
     --hash=sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e \
-    --hash=sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335 \
+    --hash=sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==42.0.1 \
     --hash=sha256:409547a87530bd8a20582a2f0996c2a6651c5855b3a614af05020b35c3867dcb \
-    --hash=sha256:be5c1ea910cd1f37d1dd79b5f74b68b359348f558fbe4866b15f54a052d61ee1 \
-    # via -r requirements.in, google-auth, ipython, jsonschema, kiwisolver, markdown, protobuf, tensorboard
+    --hash=sha256:be5c1ea910cd1f37d1dd79b5f74b68b359348f558fbe4866b15f54a052d61ee1
+    # via
+    #   -r requirements.in
+    #   google-auth
+    #   ipython
+    #   kiwisolver
+    #   tensorboard

--- a/spark/README.md
+++ b/spark/README.md
@@ -2,83 +2,62 @@
 
 ## Available images
 
-| Image location                   | Versioning     | Source                                                                                                                                         | Description                                  |
-| -------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| pubnative/spark:spark            | $SPARK_VERSION | [Apache Spark](https://github.com/apache/spark)                                                                                                | Base image for Spark.                        |
-| pubnative/spark:pyspark          | $SPARK_VERSION | [Apache Spark](https://github.com/apache/spark)                                                                                                | Base image for PySpark.                      |
-| pubnative/spark:pyspark-executor | $GIT_COMMIT    | [Pyspark executor](https://github.com/pubnative/docker-images/blob/4e940e55cb25b6541607990733222d1800674170/spark/pyspark-executor/Dockerfile) | Alpine image supporting Spark on Kubernetes. |
-
+| Image location                   | Versioning                                                                      | Source                                                                                                                                         | Description                                  |
+| -------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| pubnative/spark:spark            | <spark_version>-<scala_version>-java<java_version>[-k8s]-hadoop<hadoop_version> | [Apache Spark](https://github.com/apache/spark)                                                                                                | Base image for Spark.                        |
+| pubnative/spark:pyspark          | <spark_version>-<scala_version>-java<java_version>[-k8s]-hadoop<hadoop_version> | [Apache Spark](https://github.com/apache/spark)                                                                                                | Base image for PySpark.                      |
+| pubnative/spark:pyspark-executor | $GIT_COMMIT                                                                     | [Pyspark executor](https://github.com/pubnative/docker-images/blob/4e940e55cb25b6541607990733222d1800674170/spark/pyspark-executor/Dockerfile) | Alpine image supporting Spark on Kubernetes. |
 
 ## Build
 
-No official images exist for Spark.
-So you will have to do everything yourself.
+No official images exist for Spark. So you will have to do everything yourself.
 
 ### Workflow
 
-#### Clone the Spark repo (yes)
+#### Build Spark
 
-To build the image, Spark needs to be built.
-To build Spark, you need the repo locally.
-
-If you have it locally, refresh it:
-
-```bash
-cd SPARK_REPO
-git fetch -p && git pull
-```
-
-Else, clone the repo somewhere:
+To build the image, Spark needs to be built. To build Spark, clone the repository and checkout the
+version to build.
 
 ```bash
 git clone https://github.com/apache/spark
+cd spark
+git checkout v3.1.1
 ```
 
-#### Build Spark
-
-You don't want to build master, so you need to checkout a specific verson.
-Usually, you need the last commit for a specific label, e.g. for `2.4.3` it is `c3e32bf06c35ba2580d46150923abfa795b4446a`.
-
-When you have the commit you want, e.g. `c3e32bf06c35ba2580d46150923abfa795b4446a`:
-
-```bash
-git checkout tags/v$SPARK_VERSION
-```
-
-Then to build Spark:
+Then build it with:
 
 ```bash
 build/mvn \
+    -Pscala-2.12 \
+    -Dscala.version=2.12.10 \
     -Pkubernetes \
+    -Phadoop-3.2 \
+    -Dhadoop.version=3.2.0 \
     -DskipTests \
     clean package
 ```
 
-This script is supposed to handle everything, including Spark and Scala versions.
-If it's the last commit of a release, it's supposed to lead  to a complete build.
+When building, take into account the profiles:
+
+- `-Pscala-2.12` will prepare the build for the 2.12 major version of Scala. Similar parameters exist for other
+  versions.
+- `-Dscala.version` will set the Scala minor version. For Jupuyter (or any Spark on client
+  mode), this should usually match.
+- `-Pkubernetes` adds Kubernetes code, if the image is thought to be executed in a Kubernetes
+  cluster. You cannot run a Spark on Kubernetes without it.
+- `-Phadoop-3.2`: can be used to use a different version Hadoop of Hadoop
+- `-Dhadoop.version` sets the minor version for the Hadoop distribution.
+
+To check all available profiles, check the `pom.xml` build file, inside `<profiles>`.
 
 #### Build the images
 
-Now, you want to build the Docker image.
-If we continue the example building `2.4.3`, run:
+Now, you want to build the Docker image. For the image, we will need to specify the JRE to include.
+If we continue the example building `3.1.1`, run:
 
 ```bash
-./bin/docker-image-tool.sh -r docker.io/pubnative -t 2.4.3 build
-```
-
-#### Push the image(s)
-
-If you want to push the Spark image:
-
-```bash
-docker push pubnative/spark:2.4.3
-```
-
-If you want to push the PySpark image:
-
-```bash
-docker tag pubnative/spark-py:2.4.3 pubnative/spark:pyspark-2.4.3
-docker push pubnative/spark:pyspark-2.4.3
+./bin/docker-image-tool.sh -r docker.io/pubnative -t 3.1.1 -b java_image_tag=8-jre-slim build
 ```
 
 **Note**: Spark builds 3 images:
@@ -87,7 +66,30 @@ docker push pubnative/spark:pyspark-2.4.3
 - `spark-py`
 - `spark-r`
 
-Right now, we don't care about `spark-r`, and we need to rename `spark-py` to map it to our registry names.
+Right now, we don't care about `spark-r`.
+
+#### Push the image(s)
+
+When pushing images, we need to rename them, to specify:
+
+- Spark version
+- Scala binary version
+- Whether or not it's a Kubernetes build
+- Hadoop version
+
+Example:
+
+```bash
+docker tag pubnative/spark:3.1.1 pubnative/spark:3.1.1-2.12.10-java8-k8s-hadoop3.2.0
+docker push pubnative/spark:3.1.1-2.12.10-java8-k8s-hadoop3.2.0
+```
+
+Example for PySpark:
+
+```bash
+docker tag pubnative/spark-py:3.1.1 pubnative/spark:pyspark-3.1.1-2.12.10-java80java8-k8s-hadoop3.2.0
+docker push pubnative/spark:pyspark-3.1.1-2.12.10-java8-k8s-hadoop3.2.0
+```
 
 ### Data science images
 

--- a/spark/README.md
+++ b/spark/README.md
@@ -74,6 +74,7 @@ When pushing images, we need to rename them, to specify:
 
 - Spark version
 - Scala binary version
+- JDK version
 - Whether or not it's a Kubernetes build
 - Hadoop version
 


### PR DESCRIPTION
Using `client` mode on Spark with Kubernetes can cause problems if the driver and the image running on the executors don't match perfectly (Spar, Scala, JDK, and Hadoop versions). This PR makes the building process and the image tagging convention more explicit, so all that information is available when pulling the image.

We also update Almond installs on Jupyter to use a Scala version from the Maven central dependency of Spark 3.1.1.

I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
