### PR TITLE
Add turnilo image building

### DIFF
--- a/turnilo/Makefile
+++ b/turnilo/Makefile
@@ -1,0 +1,16 @@
+NAME := pubnative/turnilo
+VERSION := 1.32.0
+VERSIONED := ${NAME}:${VERSION}
+TMPDIR := $(shell mktemp -d)
+ 
+all: build push
+
+build:
+	git clone git@github.com:allegro/turnilo.git ${TMPDIR}/turnilo
+	cd ${TMPDIR}/turnilo; \
+	git checkout ${VERSION}; \
+	docker build --rm . -t ${VERSIONED}
+	rm -rf ${TMPDIR}
+
+push:
+	docker push ${VERSIONED}

--- a/turnilo/README.md
+++ b/turnilo/README.md
@@ -1,0 +1,25 @@
+# Turnilo
+
+Image containing [Turnilo][1] (a Druid frontebd). Images are published to `pubnative/turnilo`
+
+## Build
+
+Set the version to build within the `Makefile` file, and then:
+
+```bash
+make build
+```
+
+## Push
+
+```bash
+make push
+```
+
+## Both
+
+```bash
+make all
+```
+
+[1]: https://github.com/allegro/turnilo


### PR DESCRIPTION
Turnilo is a frontend for exploring Apache Druid data. This PR adds a build for Turnilo images.

I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
