### PR TITLE
[DI-6404] Build Trino image w JMX prometheus exporter

### DIFF
--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -1,0 +1,8 @@
+ARG TRINO_VERSION="399"
+ARG AGENT_VERSION="0.17.2"
+
+FROM trinodb/trino:${TRINO_VERSION}
+
+RUN curl -o /usr/lib/trino/lib/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${AGENT_VERSION}/jmx_prometheus_javaagent-${AGENT_VERSION}.jar
+
+COPY config.yaml /usr/lib/trino/

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -1,8 +1,9 @@
 ARG TRINO_VERSION="399"
-ARG AGENT_VERSION="0.17.2"
 
 FROM trinodb/trino:${TRINO_VERSION}
 
+ARG AGENT_VERSION="0.17.2"
+
 RUN curl -o /usr/lib/trino/lib/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${AGENT_VERSION}/jmx_prometheus_javaagent-${AGENT_VERSION}.jar
 
-COPY config.yaml /usr/lib/trino/
+COPY --chown=trino:trino config.yaml /usr/lib/trino/

--- a/trino/Makefile
+++ b/trino/Makefile
@@ -1,0 +1,26 @@
+TRINO_VERSION?=399
+AGENT_VERSION?=0.17.2
+COMMIT=$(shell git log -1 --pretty=%h)
+VERSION=v$(TRINO_VERSION)-$(COMMIT)
+DOCKER_REPO=pubnative/trino
+DOCKER_REPO_DOCKERFILE_FOLDER?=.
+DOCKER_REPO_VERSION=$(DOCKER_REPO):$(VERSION)
+DOCKER_REPO_LATEST=$(DOCKER_REPO):latest
+
+build:
+	docker build \
+	    --platform linux/amd64 \
+	    --build-arg TRINO_VERSION=$(TRINO_VERSION) \
+	    --build-arg AGENT_VERSION=$(AGENT_VERSION) \
+	    -t $(DOCKER_REPO_VERSION) \
+	    $(DOCKER_REPO_DOCKERFILE_FOLDER)
+
+	docker tag $(DOCKER_REPO_VERSION) $(DOCKER_REPO_LATEST)
+
+publish: publish-latest publish-version
+
+publish-latest: build
+    docker push $(DOCKER_REPO_LATEST)
+
+publish-version: build
+	docker push $(DOCKER_REPO_VERSION)

--- a/trino/README.md
+++ b/trino/README.md
@@ -1,0 +1,26 @@
+# Trino 
+
+Image used for our Trino deployment.
+It builds one image and tags it as:
+
+- `pubnative/trino:latest`,
+- `pubnative/trino:${TRINO_VERSION}-${COMMIT}`
+
+## Build
+
+`make build`
+
+## Deploy
+
+`make publish`
+
+## Update requirements.txt
+
+`make update-req`
+
+## Docker image locally
+
+``` 
+docker build --build-arg TRINO_VERSION=399 --build-arg AGENT_VERSION=0.17.2 -t trino_test .
+docker run -it trino_test /bin/bash
+```

--- a/trino/README.md
+++ b/trino/README.md
@@ -14,10 +14,6 @@ It builds one image and tags it as:
 
 `make publish`
 
-## Update requirements.txt
-
-`make update-req`
-
 ## Docker image locally
 
 ``` 

--- a/trino/config.yaml
+++ b/trino/config.yaml
@@ -1,0 +1,2 @@
+rules:
+  - pattern: ".*"


### PR DESCRIPTION
I confirm that I have added:

- [X] A comment to every Dockerfile with information about target repository and tag (version).
- [X] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.

Trino Docker image with JMX prometheus exporter JAR