### PR TITLE
[OPS-8906] bumping to 2.4.8 to fix 139 exits

### DIFF
--- a/proxysql/Dockerfile
+++ b/proxysql/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:7
 
-MAINTAINER PubNative <pubnative-backend@pubnative.net>
+LABEL maintainer="PubNative <pubnative-backend@pubnative.net>"
 
 RUN yum update -y
-RUN yum install -y https://github.com/sysown/proxysql/releases/download/v2.0.8/proxysql-2.0.8-1-centos7.x86_64.rpm
+# RUN yum install -y https://github.com/sysown/proxysql/releases/download/v2.0.8/proxysql-2.0.8-1-centos7.x86_64.rpm
+RUN yum install -y https://github.com/sysown/proxysql/releases/download/v2.4.8/proxysql-2.4.8-1-centos7.x86_64.rpm
 
 EXPOSE 3306 6032
 


### PR DESCRIPTION
I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.\

The existing image had a known issue which caused the container to exit with 139. Fixing it with image version 2.4.8.
Still a candidate to be tested
Label changes is to correct the deprecated `Maintainer` instruction
