### PR TITLE
[DI-6918] Upgrade Airflow version

### DIFF
--- a/airflow/Makefile
+++ b/airflow/Makefile
@@ -1,5 +1,5 @@
 AIRFLOW_VERSION := 2.7.3
-PYTHON_VERSION := 3.12.0
+PYTHON_VERSION := 3.11.6
 COMMIT := $(shell git log -1 --pretty=%h)
 VERSION := v${AIRFLOW_VERSION}-${COMMIT}
 DOCKER_REPO := pubnative/airflow-2

--- a/airflow/Makefile
+++ b/airflow/Makefile
@@ -1,5 +1,5 @@
-AIRFLOW_VERSION := 2.5.1
-PYTHON_VERSION := 3.7
+AIRFLOW_VERSION := 2.7.3
+PYTHON_VERSION := 3.12
 COMMIT := $(shell git log -1 --pretty=%h)
 VERSION := v${AIRFLOW_VERSION}-${COMMIT}
 DOCKER_REPO := pubnative/airflow-2

--- a/airflow/Makefile
+++ b/airflow/Makefile
@@ -1,5 +1,5 @@
 AIRFLOW_VERSION := 2.7.3
-PYTHON_VERSION := 3.12
+PYTHON_VERSION := 3.12.0
 COMMIT := $(shell git log -1 --pretty=%h)
 VERSION := v${AIRFLOW_VERSION}-${COMMIT}
 DOCKER_REPO := pubnative/airflow-2

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -21,7 +21,7 @@ It builds one image and tags it as:
 ## Docker image locally
 
 ``` 
-docker build --build-arg AIRFLOW_VERSION=2.7.3 --build-arg PYTHON_VERSION=3.12.0 -t airflow_test .
+docker build --build-arg AIRFLOW_VERSION=2.7.3 --build-arg PYTHON_VERSION=3.11.6 -t airflow_test .
 docker run airflow_test -h
 ```
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -21,7 +21,7 @@ It builds one image and tags it as:
 ## Docker image locally
 
 ``` 
-docker build --build-arg AIRFLOW_VERSION=2.5.1 --build-arg PYTHON_VERSION=3.7 -t airflow_test .
+docker build --build-arg AIRFLOW_VERSION=2.7.3 --build-arg PYTHON_VERSION=3.12.0 -t airflow_test .
 docker run airflow_test -h
 ```
 

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -1,26 +1,26 @@
 [tool.poetry]
 name = "airflow"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "3.7.12"
-boto3 = "^1.10.40"
-pyathena = "^1.9.0"
-pyyaml = "^5.3"
-google-api-python-client = "^1.12.8"
-google-cloud-storage = "^1.36.2"
-pandas-gbq = "0.13.2"
-influxdb = "5.2.1"
-apache-airflow = "2.5.1"
+python = "3.12.0"
+boto3 = "^1.28.85"
+pyathena = "^3.0.10"
+pyyaml = "^6.0"
+google-api-python-client = "^2.108.0"
+google-cloud-storage = "^2.13.0"
+pandas-gbq = "0.19.2"
+influxdb = "5.3.1"
+apache-airflow = "2.7.3"
 apache-airflow-providers-cncf-kubernetes = "4.3.0"
-apache-airflow-providers-google = "8.3.0"
-apache-airflow-providers-influxdb = "2.0.0"
-apache-airflow-providers-apache-spark = "3.0.0"
-apache-airflow-providers-amazon = "5.0.0"
-flask-admin = "^1.5.8"
-protobuf = "3.20.*"
+apache-airflow-providers-google = "10.11.1"
+apache-airflow-providers-influxdb = "2.3.0"
+apache-airflow-providers-apache-spark = "4.4.0"
+apache-airflow-providers-amazon = "8.11.0"
+flask-admin = "^1.6.0"
+protobuf = "4.25.*"
 
 [tool.poetry.dev-dependencies]
 

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "3.12.0"
+python = "3.11.6"
 boto3 = "^1.28.85"
 pyathena = "^3.0.10"
 pyyaml = "^6.0"


### PR DESCRIPTION
In this PR I am upgrading Airflow to the latest version(2.7.3), Python to the latest supported version(3.11.6) and all packages to their latest version. 

I will share how we can safely test it and roll it out in a different document

I confirm that I have added:

- [X] A comment to every Dockerfile with information about target repository and tag (version).
- [X] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
