### PR TITLE
[DI-6917] Upgrade Druid version to 28

### DIFF
--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -10,8 +10,9 @@ ARG MYSQL_JAR=mysql-connector-java-5.1.49.jar
 # https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar.sha1
 ARG MYSQL_SHA=cf76d2e4c9c3782a85c15c87bec5772b34ffd0e5
 
-RUN wget -q ${MYSQL_URL} \
- && echo "${MYSQL_SHA}  ${MYSQL_JAR}" | sha1sum -c \
+ADD --chown=druid:druid ${MYSQL_URL} /opt/druid/extensions/mysql-metadata-storage/
+
+RUN echo "${MYSQL_SHA}  ${MYSQL_JAR}" | sha1sum -c \
  && ln -s ../extensions/mysql-metadata-storage/${MYSQL_JAR} /opt/druid/lib
 
 WORKDIR /opt/druid

--- a/druid/Makefile
+++ b/druid/Makefile
@@ -1,4 +1,4 @@
-DRUID_VERSION := 27.0.0
+DRUID_VERSION := 28.0.0
 COMMIT := $(shell git log -1 --pretty=%h)
 VERSION := v${DRUID_VERSION}-${COMMIT}
 DOCKER_REPO := pubnative/druid

--- a/druid/README.md
+++ b/druid/README.md
@@ -17,6 +17,6 @@ It builds one image and tags it as:
 ## Docker image locally
 
 ```
-docker build --build-arg DRUID_VERSION=27.0.0 -t druid_test .
+docker build --build-arg DRUID_VERSION=28.0.0 -t druid_test .
 docker run -it --entrypoint /bin/bash druid_test 
 ```

--- a/druid/README.md
+++ b/druid/README.md
@@ -18,5 +18,5 @@ It builds one image and tags it as:
 
 ```
 docker build --build-arg DRUID_VERSION=27.0.0 -t druid_test .
-docker run -it druid_test 
+docker run -it --entrypoint /bin/bash druid_test 
 ```

--- a/druid/single-container-druid/README.md
+++ b/druid/single-container-druid/README.md
@@ -28,5 +28,5 @@ testing.
 
 ```
 docker build --build-arg DRUID_VERSION=28.0.0 -t druid_test .
-docker run -it druid_test 
+docker run -it --entrypoint /bin/bash druid_test 
 ```


### PR DESCRIPTION
Upgrading Druid to version 28.0.0 requires moving away from wget 

I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
