### PR TITLE
rebuild pyspark image with python3.11

### DIFF
--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -10,7 +10,7 @@ pyspark:
 	docker-image-tool.sh \
 		-r ${OWNER} \
 		-t v3.4.1 \
-		-p ${SPARK_HOME}/kubernetes/dockerfiles/spark/bindings/python/Dockerfile \
+		-p ./bindings/python/Dockerfile \
 		build
 
 build: pyspark

--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -3,8 +3,6 @@ REPO			:= ${OWNER}/pyspark
 TAG				:= v3.4.1
 IMAGE			:= ${REPO}:${TAG}
 
-
-
 pyspark:
 	@echo ${SPARK_HOME}
 	docker-image-tool.sh \

--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -1,6 +1,6 @@
 OWNER			:= pubnative
 REPO			:= ${OWNER}/pyspark
-TAG				:= v3.4.1
+TAG				:= v3.4.1-python3.11
 IMAGE			:= ${REPO}:${TAG}
 
 pyspark:

--- a/pyspark/README.md
+++ b/pyspark/README.md
@@ -1,8 +1,7 @@
 # Base data science pyspark image
 This image is also used for jupyterhub spark executors. It is passed via spark defaults and mounted onto the deployment in data-tasks
 ## build pyspark image with docker image tool
-- Make sure your SPARK_HOME is set to the SPARK 3.2.2
-- We need to build this with java8 so that it is compatible with gcs-connector
+- Make sure your SPARK_HOME is set to the SPARK 3.4.1
 ```sh
 make pyspark
 ```

--- a/pyspark/bindings/python/Dockerfile
+++ b/pyspark/bindings/python/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG base_img
+
+FROM $base_img
+WORKDIR /
+
+# Reset to root to run installation tasks
+USER 0
+
+RUN mkdir ${SPARK_HOME}/python
+RUN apt-get update && \
+    apt install -y python3 python3-pip && \
+    pip3 install --upgrade pip setuptools && \
+    # Removed the .cache to save space
+    rm -rf /root/.cache && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
+
+COPY python/pyspark ${SPARK_HOME}/python/pyspark
+COPY python/lib ${SPARK_HOME}/python/lib
+
+WORKDIR /opt/spark/work-dir
+ENTRYPOINT [ "/opt/entrypoint.sh" ]
+
+# Specify the User that the actual main process will run as
+ARG spark_uid=185
+USER ${spark_uid}

--- a/pyspark/bindings/python/Dockerfile
+++ b/pyspark/bindings/python/Dockerfile
@@ -24,12 +24,11 @@ WORKDIR /
 USER 0
 
 RUN mkdir ${SPARK_HOME}/python
-RUN apt-get update && \
-    apt install -y python3 python3-pip && \
-    pip3 install --upgrade pip setuptools && \
+RUN apt-get update && apt install -y python3.11 python3-pip
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python3
+RUN pip3 install --upgrade pip setuptools && \
     # Removed the .cache to save space
     rm -rf /root/.cache && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
-
 COPY python/pyspark ${SPARK_HOME}/python/pyspark
 COPY python/lib ${SPARK_HOME}/python/lib
 


### PR DESCRIPTION
# what is done in this PR ?
- instead of using default python binding from spark distribution, i created new binding and pass them to docker image tool for building intermediation local image spark-py:v3.4.1
- this is then used as base image for the image pubnative/pyspark which is pushed to docker with tag v3.4.1-python3.11

# changes to binding
- python3.11 is installed instead of python3. this installs python3.11.0-rc1 along side python3.10 which is system python
- python3 soft link is update to point to python3.11 instead of python3.10
- after this pip is upgraded so it correctly pick up python3.11

# why did we do this?
spark fails when minor version of python is not matching on drivers and executors
on jupyter driver has python 3.11
and now on executors we will also have python3.11


I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
