### PR TITLE
Upgrade java version from 8 to 11 for sbt image

### DIFF
--- a/sbt-ci/Dockerfile
+++ b/sbt-ci/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     curl \
     gnupg \
     wget \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     openssl \
     apt-transport-https \
     ca-certificates \


### PR DESCRIPTION
I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
