### PR TITLE
[DI-7701] Add deployment plugin for airflow

### DIFF
--- a/airflow/plugins/deployment_plugin.py
+++ b/airflow/plugins/deployment_plugin.py
@@ -1,0 +1,14 @@
+from airflow.plugins_manager import AirflowPlugin
+
+import os
+
+def deploy_in_env(dag):
+    if os.getenv("ENV") == 'prod':
+        return dag
+    else:
+        print("Not in production environment. Skipping DAG creation.")
+        return None
+
+class DeploymentPlugin(AirflowPlugin):
+    name = "deployment_plugin"
+    macros = [deploy_in_env]


### PR DESCRIPTION
Add a deployment plugin for Airflow.

I confirm that I have added:

- [x] A comment to every Dockerfile with information about target repository and tag (version).
- [x] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
