### PR TITLE
Upgrade google cloud dataproc package in Airflow

### DIFF
--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -8,13 +8,13 @@ dependencies = [
     "boto3 ~= 1.15",
     "pyathena ~= 1.9.0",
     "pyyaml >= 5.5",
-    "google-api-python-client ~= 1.12.8",
-    "google-cloud-storage ~= 1.36.2",
+    "google-api-python-client ~= 2.156.0",
+    "google-cloud-storage ~= 2.19.0",
     "pandas-gbq == 0.13.2",
     "influxdb == 5.2.1",
     "apache-airflow == 2.5.1",
     "apache-airflow-providers-cncf-kubernetes == 4.3.0",
-    "apache-airflow-providers-google == 8.3.0",
+    "apache-airflow-providers-google == 10.7.0",
     "apache-airflow-providers-influxdb == 2.0.0",
     "apache-airflow-providers-apache-spark == 3.0.0",
     "apache-airflow-providers-amazon == 5.0.0",
@@ -35,7 +35,6 @@ dependencies = [
     "werkzeug==2.2.3",
     "connexion==2.14.2",
     "pydantic>=2.9.2",
-    "google-cloud-dataproc==5.11.0",
 ]
 readme = "README.md"
 requires-python = "==3.10.14"

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "werkzeug==2.2.3",
     "connexion==2.14.2",
     "pydantic>=2.9.2",
+    "google-cloud-dataproc==5.11.0",
 ]
 readme = "README.md"
 requires-python = "==3.10.14"

--- a/airflow/requirements-dev.lock
+++ b/airflow/requirements-dev.lock
@@ -10,15 +10,19 @@
 #   universal: false
 
 -e file:.
+aiofiles==23.2.1
+    # via gcloud-aio-storage
 aiohappyeyeballs==2.4.3
     # via aiohttp
 aiohttp==3.10.10
     # via apache-airflow-providers-http
+    # via gcloud-aio-auth
     # via gcsfs
 aiosignal==1.3.1
     # via aiohttp
 alembic==1.13.3
     # via apache-airflow
+    # via sqlalchemy-spanner
 annotated-types==0.7.0
     # via pydantic
 anyio==4.5.2
@@ -48,7 +52,7 @@ apache-airflow-providers-common-sql==1.8.1
     # via apache-airflow-providers-sqlite
 apache-airflow-providers-ftp==3.6.1
     # via apache-airflow
-apache-airflow-providers-google==8.3.0
+apache-airflow-providers-google==10.7.0
     # via airflow
 apache-airflow-providers-http==4.7.0
     # via apache-airflow
@@ -63,6 +67,7 @@ apispec==3.3.2
 argcomplete==3.5.1
     # via apache-airflow
 asgiref==3.8.1
+    # via apache-airflow-providers-google
     # via apache-airflow-providers-http
 asn1crypto==1.5.1
     # via scramp
@@ -77,6 +82,8 @@ attrs==24.2.0
     # via referencing
 babel==2.16.0
     # via flask-babel
+backoff==2.2.1
+    # via gcloud-aio-auth
 beautifulsoup4==4.12.3
     # via redshift-connector
 blinker==1.8.2
@@ -108,6 +115,8 @@ certifi==2024.8.30
     # via requests
 cffi==1.17.1
     # via cryptography
+chardet==4.0.0
+    # via gcloud-aio-auth
 charset-normalizer==3.4.0
     # via requests
 click==8.1.7
@@ -129,9 +138,10 @@ cron-descriptor==1.4.5
     # via apache-airflow
 croniter==5.0.1
     # via apache-airflow
-cryptography==43.0.3
+cryptography==38.0.4
     # via apache-airflow
     # via apache-airflow-providers-cncf-kubernetes
+    # via gcloud-aio-auth
     # via pyopenssl
 datadog==0.50.1
     # via airflow
@@ -139,6 +149,8 @@ decorator==5.1.1
     # via gcsfs
 deprecated==1.2.14
     # via apache-airflow
+    # via opentelemetry-api
+    # via opentelemetry-semantic-conventions
 dill==0.3.9
     # via apache-airflow
 dnspython==2.6.1
@@ -191,26 +203,38 @@ frozenlist==1.5.0
     # via aiosignal
 fsspec==2024.10.0
     # via gcsfs
-future==1.0.0
+future==0.18.3
+    # via gcloud-aio-auth
     # via pyathena
+gcloud-aio-auth==4.1.5
+    # via apache-airflow-providers-google
+    # via gcloud-aio-bigquery
+    # via gcloud-aio-storage
+gcloud-aio-bigquery==7.1.0
+    # via apache-airflow-providers-google
+gcloud-aio-storage==9.2.0
+    # via apache-airflow-providers-google
 gcsfs==2024.10.0
     # via airflow
 google-ads==22.0.0
     # via apache-airflow-providers-google
-google-api-core==2.10.2
+google-api-core==2.24.0
     # via apache-airflow-providers-google
     # via google-ads
     # via google-api-python-client
     # via google-cloud-aiplatform
     # via google-cloud-appengine-logging
     # via google-cloud-automl
+    # via google-cloud-batch
     # via google-cloud-bigquery
     # via google-cloud-bigquery-datatransfer
     # via google-cloud-bigtable
     # via google-cloud-build
+    # via google-cloud-compute
     # via google-cloud-container
     # via google-cloud-core
     # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
     # via google-cloud-dataform
     # via google-cloud-dataplex
     # via google-cloud-dataproc
@@ -226,9 +250,12 @@ google-api-core==2.10.2
     # via google-cloud-pubsub
     # via google-cloud-redis
     # via google-cloud-resource-manager
+    # via google-cloud-run
     # via google-cloud-secret-manager
     # via google-cloud-spanner
     # via google-cloud-speech
+    # via google-cloud-storage
+    # via google-cloud-storage-transfer
     # via google-cloud-tasks
     # via google-cloud-texttospeech
     # via google-cloud-translate
@@ -236,18 +263,50 @@ google-api-core==2.10.2
     # via google-cloud-vision
     # via google-cloud-workflows
     # via sqlalchemy-bigquery
-google-api-python-client==1.12.11
+google-api-python-client==2.156.0
     # via airflow
     # via apache-airflow-providers-google
-google-auth==1.35.0
+google-auth==2.37.0
     # via apache-airflow-providers-google
     # via gcsfs
     # via google-api-core
     # via google-api-python-client
     # via google-auth-httplib2
     # via google-auth-oauthlib
+    # via google-cloud-automl
+    # via google-cloud-batch
+    # via google-cloud-bigquery-datatransfer
+    # via google-cloud-bigtable
+    # via google-cloud-build
+    # via google-cloud-compute
+    # via google-cloud-container
     # via google-cloud-core
+    # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
+    # via google-cloud-dataform
+    # via google-cloud-dataplex
+    # via google-cloud-dataproc
+    # via google-cloud-dataproc-metastore
+    # via google-cloud-dlp
+    # via google-cloud-kms
+    # via google-cloud-language
+    # via google-cloud-logging
+    # via google-cloud-memcache
+    # via google-cloud-orchestration-airflow
+    # via google-cloud-os-login
+    # via google-cloud-pubsub
+    # via google-cloud-redis
+    # via google-cloud-run
+    # via google-cloud-secret-manager
+    # via google-cloud-speech
     # via google-cloud-storage
+    # via google-cloud-storage-transfer
+    # via google-cloud-tasks
+    # via google-cloud-texttospeech
+    # via google-cloud-translate
+    # via google-cloud-videointelligence
+    # via google-cloud-vision
+    # via google-cloud-workflows
     # via kubernetes
     # via pandas-gbq
     # via pydata-google-auth
@@ -266,85 +325,97 @@ google-cloud-appengine-logging==1.1.6
     # via google-cloud-logging
 google-cloud-audit-log==0.3.0
     # via google-cloud-logging
-google-cloud-automl==2.8.3
+google-cloud-automl==2.15.0
+    # via apache-airflow-providers-google
+google-cloud-batch==0.17.32
     # via apache-airflow-providers-google
 google-cloud-bigquery==3.18.0
     # via google-cloud-aiplatform
     # via pandas-gbq
     # via sqlalchemy-bigquery
-google-cloud-bigquery-datatransfer==3.7.3
+google-cloud-bigquery-datatransfer==3.18.0
     # via apache-airflow-providers-google
-google-cloud-bigtable==1.7.3
+google-cloud-bigtable==2.27.0
     # via apache-airflow-providers-google
-google-cloud-build==3.9.3
+google-cloud-build==3.28.0
     # via apache-airflow-providers-google
-google-cloud-container==2.13.0
+google-cloud-compute==1.23.0
     # via apache-airflow-providers-google
-google-cloud-core==1.7.3
+google-cloud-container==2.55.0
+    # via apache-airflow-providers-google
+google-cloud-core==2.4.1
     # via google-cloud-bigquery
     # via google-cloud-bigtable
     # via google-cloud-logging
     # via google-cloud-spanner
     # via google-cloud-storage
     # via google-cloud-translate
-google-cloud-datacatalog==3.9.3
+google-cloud-datacatalog==3.24.1
     # via apache-airflow-providers-google
-google-cloud-dataform==0.2.3
+google-cloud-dataflow-client==0.8.15
     # via apache-airflow-providers-google
-google-cloud-dataplex==1.1.3
+google-cloud-dataform==0.5.14
     # via apache-airflow-providers-google
-google-cloud-dataproc==5.0.3
+google-cloud-dataplex==2.5.0
     # via apache-airflow-providers-google
-google-cloud-dataproc-metastore==1.6.3
+google-cloud-dataproc==5.11.0
     # via apache-airflow-providers-google
-google-cloud-dlp==1.0.2
+google-cloud-dataproc-metastore==1.17.0
     # via apache-airflow-providers-google
-google-cloud-kms==2.12.3
+google-cloud-dlp==3.26.0
     # via apache-airflow-providers-google
-google-cloud-language==1.3.2
+google-cloud-kms==3.2.1
     # via apache-airflow-providers-google
-google-cloud-logging==3.1.2
+google-cloud-language==2.16.0
     # via apache-airflow-providers-google
-google-cloud-memcache==1.4.4
+google-cloud-logging==3.11.3
+    # via apache-airflow-providers-google
+google-cloud-memcache==1.11.0
     # via apache-airflow-providers-google
 google-cloud-monitoring==2.16.0
     # via apache-airflow-providers-google
-google-cloud-orchestration-airflow==1.4.4
+google-cloud-orchestration-airflow==1.16.0
     # via apache-airflow-providers-google
-google-cloud-os-login==2.7.4
+google-cloud-os-login==2.16.0
     # via apache-airflow-providers-google
-google-cloud-pubsub==2.13.11
+google-cloud-pubsub==2.27.1
     # via apache-airflow-providers-google
-google-cloud-redis==2.9.3
+google-cloud-redis==2.17.0
     # via apache-airflow-providers-google
 google-cloud-resource-manager==1.6.3
     # via google-cloud-aiplatform
-google-cloud-secret-manager==1.0.2
+google-cloud-run==0.10.14
     # via apache-airflow-providers-google
-google-cloud-spanner==1.19.3
+google-cloud-secret-manager==2.22.0
     # via apache-airflow-providers-google
-google-cloud-speech==1.3.4
+google-cloud-spanner==3.51.0
     # via apache-airflow-providers-google
-google-cloud-storage==1.36.2
+    # via sqlalchemy-spanner
+google-cloud-speech==2.29.0
+    # via apache-airflow-providers-google
+google-cloud-storage==2.19.0
     # via airflow
     # via apache-airflow-providers-google
     # via gcsfs
     # via google-cloud-aiplatform
-google-cloud-tasks==2.10.4
+google-cloud-storage-transfer==1.15.0
     # via apache-airflow-providers-google
-google-cloud-texttospeech==1.0.3
+google-cloud-tasks==2.18.0
     # via apache-airflow-providers-google
-google-cloud-translate==1.7.2
+google-cloud-texttospeech==2.23.0
     # via apache-airflow-providers-google
-google-cloud-videointelligence==1.16.3
+google-cloud-translate==3.19.0
     # via apache-airflow-providers-google
-google-cloud-vision==1.0.2
+google-cloud-videointelligence==2.15.0
     # via apache-airflow-providers-google
-google-cloud-workflows==1.7.4
+google-cloud-vision==3.9.0
+    # via apache-airflow-providers-google
+google-cloud-workflows==1.16.0
     # via apache-airflow-providers-google
 google-crc32c==1.5.0
+    # via google-cloud-storage
     # via google-resumable-media
-google-resumable-media==1.3.3
+google-resumable-media==2.7.2
     # via google-cloud-bigquery
     # via google-cloud-storage
 googleapis-common-protos==1.65.0
@@ -359,28 +430,34 @@ greenlet==3.1.1
     # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via google-cloud-bigtable
-    # via google-cloud-container
+    # via google-cloud-build
     # via google-cloud-datacatalog
     # via google-cloud-dataform
     # via google-cloud-dataplex
+    # via google-cloud-dataproc
+    # via google-cloud-dataproc-metastore
     # via google-cloud-kms
     # via google-cloud-logging
     # via google-cloud-pubsub
     # via google-cloud-resource-manager
+    # via google-cloud-run
     # via google-cloud-secret-manager
     # via google-cloud-spanner
     # via google-cloud-tasks
+    # via google-cloud-translate
+grpc-interceptor==0.15.4
+    # via google-cloud-spanner
 grpcio==1.67.1
     # via google-ads
     # via google-api-core
     # via google-cloud-pubsub
     # via googleapis-common-protos
     # via grpc-google-iam-v1
+    # via grpc-interceptor
     # via grpcio-gcp
     # via grpcio-status
 grpcio-gcp==0.2.2
     # via apache-airflow-providers-google
-    # via google-api-core
 grpcio-status==1.48.2
     # via google-ads
     # via google-api-core
@@ -403,6 +480,8 @@ idna==3.10
     # via httpx
     # via requests
     # via yarl
+importlib-metadata==8.5.0
+    # via opentelemetry-api
 inflection==0.5.1
     # via connexion
 influxdb==5.2.1
@@ -490,6 +569,15 @@ oauthlib==3.2.2
     # via requests-oauthlib
 openpyxl==3.1.5
     # via airflow
+opentelemetry-api==1.29.0
+    # via google-cloud-logging
+    # via google-cloud-pubsub
+    # via opentelemetry-sdk
+    # via opentelemetry-semantic-conventions
+opentelemetry-sdk==1.29.0
+    # via google-cloud-pubsub
+opentelemetry-semantic-conventions==0.50b0
+    # via opentelemetry-sdk
 packaging==24.1
     # via apache-airflow
     # via connexion
@@ -524,41 +612,18 @@ propcache==0.2.0
 proto-plus==1.25.0
     # via apache-airflow-providers-google
     # via google-ads
-    # via google-cloud-aiplatform
-    # via google-cloud-appengine-logging
-    # via google-cloud-automl
-    # via google-cloud-bigquery-datatransfer
-    # via google-cloud-build
-    # via google-cloud-container
-    # via google-cloud-datacatalog
-    # via google-cloud-dataform
-    # via google-cloud-dataplex
-    # via google-cloud-dataproc
-    # via google-cloud-dataproc-metastore
-    # via google-cloud-kms
-    # via google-cloud-logging
-    # via google-cloud-memcache
-    # via google-cloud-monitoring
-    # via google-cloud-orchestration-airflow
-    # via google-cloud-os-login
-    # via google-cloud-pubsub
-    # via google-cloud-redis
-    # via google-cloud-resource-manager
-    # via google-cloud-tasks
-    # via google-cloud-workflows
-protobuf==3.20.3
-    # via airflow
-    # via google-ads
     # via google-api-core
     # via google-cloud-aiplatform
     # via google-cloud-appengine-logging
-    # via google-cloud-audit-log
     # via google-cloud-automl
+    # via google-cloud-batch
     # via google-cloud-bigquery-datatransfer
     # via google-cloud-bigtable
     # via google-cloud-build
+    # via google-cloud-compute
     # via google-cloud-container
     # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
     # via google-cloud-dataform
     # via google-cloud-dataplex
     # via google-cloud-dataproc
@@ -574,9 +639,53 @@ protobuf==3.20.3
     # via google-cloud-pubsub
     # via google-cloud-redis
     # via google-cloud-resource-manager
+    # via google-cloud-run
     # via google-cloud-secret-manager
     # via google-cloud-spanner
     # via google-cloud-speech
+    # via google-cloud-storage-transfer
+    # via google-cloud-tasks
+    # via google-cloud-texttospeech
+    # via google-cloud-translate
+    # via google-cloud-videointelligence
+    # via google-cloud-vision
+    # via google-cloud-workflows
+protobuf==3.20.3
+    # via airflow
+    # via google-ads
+    # via google-api-core
+    # via google-cloud-aiplatform
+    # via google-cloud-appengine-logging
+    # via google-cloud-audit-log
+    # via google-cloud-automl
+    # via google-cloud-batch
+    # via google-cloud-bigquery-datatransfer
+    # via google-cloud-bigtable
+    # via google-cloud-build
+    # via google-cloud-compute
+    # via google-cloud-container
+    # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
+    # via google-cloud-dataform
+    # via google-cloud-dataplex
+    # via google-cloud-dataproc
+    # via google-cloud-dataproc-metastore
+    # via google-cloud-dlp
+    # via google-cloud-kms
+    # via google-cloud-language
+    # via google-cloud-logging
+    # via google-cloud-memcache
+    # via google-cloud-monitoring
+    # via google-cloud-orchestration-airflow
+    # via google-cloud-os-login
+    # via google-cloud-pubsub
+    # via google-cloud-redis
+    # via google-cloud-resource-manager
+    # via google-cloud-run
+    # via google-cloud-secret-manager
+    # via google-cloud-spanner
+    # via google-cloud-speech
+    # via google-cloud-storage-transfer
     # via google-cloud-tasks
     # via google-cloud-texttospeech
     # via google-cloud-translate
@@ -591,10 +700,11 @@ psutil==6.1.0
     # via apache-airflow
 py4j==0.10.9.7
     # via pyspark
-pyasn1==0.6.1
+pyasn1==0.5.1
     # via pyasn1-modules
     # via rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.3.0
+    # via gcloud-aio-storage
     # via google-auth
 pyathena==1.9.0
     # via airflow
@@ -615,9 +725,10 @@ pyjwt==2.9.0
     # via apache-airflow
     # via flask-appbuilder
     # via flask-jwt-extended
+    # via gcloud-aio-auth
 pymeta3==0.5.1
     # via pybars3
-pyopenssl==24.2.1
+pyopenssl==23.2.0
     # via apache-airflow-providers-google
 pyparsing==3.1.4
     # via httplib2
@@ -691,6 +802,7 @@ rpds-py==0.20.0
     # via jsonschema
     # via referencing
 rsa==4.9
+    # via gcloud-aio-storage
     # via google-auth
 s3transfer==0.10.3
     # via boto3
@@ -700,7 +812,6 @@ setproctitle==1.3.3
     # via apache-airflow
 setuptools==75.3.0
     # via google-ads
-    # via google-auth
     # via influxdb-client
     # via kubernetes
     # via pandas-gbq
@@ -710,10 +821,7 @@ setuptools==75.3.0
 shapely==2.0.6
     # via google-cloud-aiplatform
 six==1.16.0
-    # via google-api-python-client
-    # via google-auth
-    # via google-cloud-core
-    # via google-resumable-media
+    # via gcloud-aio-auth
     # via influxdb
     # via kubernetes
     # via prison
@@ -735,6 +843,7 @@ sqlalchemy==1.4.46
     # via sqlalchemy-bigquery
     # via sqlalchemy-jsonfield
     # via sqlalchemy-redshift
+    # via sqlalchemy-spanner
     # via sqlalchemy-utils
 sqlalchemy-bigquery==1.12.0
     # via apache-airflow-providers-google
@@ -742,10 +851,13 @@ sqlalchemy-jsonfield==1.0.2
     # via apache-airflow
 sqlalchemy-redshift==0.8.14
     # via apache-airflow-providers-amazon
+sqlalchemy-spanner==1.8.0
+    # via apache-airflow-providers-google
 sqlalchemy-utils==0.41.2
     # via flask-appbuilder
 sqlparse==0.5.1
     # via apache-airflow-providers-common-sql
+    # via google-cloud-spanner
 tabulate==0.9.0
     # via apache-airflow
 tenacity==9.0.0
@@ -766,6 +878,7 @@ typing-extensions==4.12.2
     # via mypy-boto3-appflow
     # via mypy-boto3-rds
     # via mypy-boto3-redshift-data
+    # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
     # via reactivex
@@ -804,3 +917,5 @@ wtforms==3.1.2
     # via flask-wtf
 yarl==1.15.2
     # via aiohttp
+zipp==3.21.0
+    # via importlib-metadata

--- a/airflow/requirements.lock
+++ b/airflow/requirements.lock
@@ -10,15 +10,19 @@
 #   universal: false
 
 -e file:.
+aiofiles==23.2.1
+    # via gcloud-aio-storage
 aiohappyeyeballs==2.4.3
     # via aiohttp
 aiohttp==3.10.10
     # via apache-airflow-providers-http
+    # via gcloud-aio-auth
     # via gcsfs
 aiosignal==1.3.1
     # via aiohttp
 alembic==1.13.3
     # via apache-airflow
+    # via sqlalchemy-spanner
 annotated-types==0.7.0
     # via pydantic
 anyio==4.5.2
@@ -48,7 +52,7 @@ apache-airflow-providers-common-sql==1.8.1
     # via apache-airflow-providers-sqlite
 apache-airflow-providers-ftp==3.6.1
     # via apache-airflow
-apache-airflow-providers-google==8.3.0
+apache-airflow-providers-google==10.7.0
     # via airflow
 apache-airflow-providers-http==4.7.0
     # via apache-airflow
@@ -63,6 +67,7 @@ apispec==3.3.2
 argcomplete==3.5.1
     # via apache-airflow
 asgiref==3.8.1
+    # via apache-airflow-providers-google
     # via apache-airflow-providers-http
 asn1crypto==1.5.1
     # via scramp
@@ -77,6 +82,8 @@ attrs==24.2.0
     # via referencing
 babel==2.16.0
     # via flask-babel
+backoff==2.2.1
+    # via gcloud-aio-auth
 beautifulsoup4==4.12.3
     # via redshift-connector
 blinker==1.8.2
@@ -108,6 +115,8 @@ certifi==2024.8.30
     # via requests
 cffi==1.17.1
     # via cryptography
+chardet==4.0.0
+    # via gcloud-aio-auth
 charset-normalizer==3.4.0
     # via requests
 click==8.1.7
@@ -129,9 +138,10 @@ cron-descriptor==1.4.5
     # via apache-airflow
 croniter==5.0.1
     # via apache-airflow
-cryptography==43.0.3
+cryptography==38.0.4
     # via apache-airflow
     # via apache-airflow-providers-cncf-kubernetes
+    # via gcloud-aio-auth
     # via pyopenssl
 datadog==0.50.1
     # via airflow
@@ -139,6 +149,8 @@ decorator==5.1.1
     # via gcsfs
 deprecated==1.2.14
     # via apache-airflow
+    # via opentelemetry-api
+    # via opentelemetry-semantic-conventions
 dill==0.3.9
     # via apache-airflow
 dnspython==2.6.1
@@ -191,26 +203,38 @@ frozenlist==1.5.0
     # via aiosignal
 fsspec==2024.10.0
     # via gcsfs
-future==1.0.0
+future==0.18.3
+    # via gcloud-aio-auth
     # via pyathena
+gcloud-aio-auth==4.1.5
+    # via apache-airflow-providers-google
+    # via gcloud-aio-bigquery
+    # via gcloud-aio-storage
+gcloud-aio-bigquery==7.1.0
+    # via apache-airflow-providers-google
+gcloud-aio-storage==9.2.0
+    # via apache-airflow-providers-google
 gcsfs==2024.10.0
     # via airflow
 google-ads==22.0.0
     # via apache-airflow-providers-google
-google-api-core==2.10.2
+google-api-core==2.24.0
     # via apache-airflow-providers-google
     # via google-ads
     # via google-api-python-client
     # via google-cloud-aiplatform
     # via google-cloud-appengine-logging
     # via google-cloud-automl
+    # via google-cloud-batch
     # via google-cloud-bigquery
     # via google-cloud-bigquery-datatransfer
     # via google-cloud-bigtable
     # via google-cloud-build
+    # via google-cloud-compute
     # via google-cloud-container
     # via google-cloud-core
     # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
     # via google-cloud-dataform
     # via google-cloud-dataplex
     # via google-cloud-dataproc
@@ -226,9 +250,12 @@ google-api-core==2.10.2
     # via google-cloud-pubsub
     # via google-cloud-redis
     # via google-cloud-resource-manager
+    # via google-cloud-run
     # via google-cloud-secret-manager
     # via google-cloud-spanner
     # via google-cloud-speech
+    # via google-cloud-storage
+    # via google-cloud-storage-transfer
     # via google-cloud-tasks
     # via google-cloud-texttospeech
     # via google-cloud-translate
@@ -236,18 +263,50 @@ google-api-core==2.10.2
     # via google-cloud-vision
     # via google-cloud-workflows
     # via sqlalchemy-bigquery
-google-api-python-client==1.12.11
+google-api-python-client==2.156.0
     # via airflow
     # via apache-airflow-providers-google
-google-auth==1.35.0
+google-auth==2.37.0
     # via apache-airflow-providers-google
     # via gcsfs
     # via google-api-core
     # via google-api-python-client
     # via google-auth-httplib2
     # via google-auth-oauthlib
+    # via google-cloud-automl
+    # via google-cloud-batch
+    # via google-cloud-bigquery-datatransfer
+    # via google-cloud-bigtable
+    # via google-cloud-build
+    # via google-cloud-compute
+    # via google-cloud-container
     # via google-cloud-core
+    # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
+    # via google-cloud-dataform
+    # via google-cloud-dataplex
+    # via google-cloud-dataproc
+    # via google-cloud-dataproc-metastore
+    # via google-cloud-dlp
+    # via google-cloud-kms
+    # via google-cloud-language
+    # via google-cloud-logging
+    # via google-cloud-memcache
+    # via google-cloud-orchestration-airflow
+    # via google-cloud-os-login
+    # via google-cloud-pubsub
+    # via google-cloud-redis
+    # via google-cloud-run
+    # via google-cloud-secret-manager
+    # via google-cloud-speech
     # via google-cloud-storage
+    # via google-cloud-storage-transfer
+    # via google-cloud-tasks
+    # via google-cloud-texttospeech
+    # via google-cloud-translate
+    # via google-cloud-videointelligence
+    # via google-cloud-vision
+    # via google-cloud-workflows
     # via kubernetes
     # via pandas-gbq
     # via pydata-google-auth
@@ -266,85 +325,97 @@ google-cloud-appengine-logging==1.1.6
     # via google-cloud-logging
 google-cloud-audit-log==0.3.0
     # via google-cloud-logging
-google-cloud-automl==2.8.3
+google-cloud-automl==2.15.0
+    # via apache-airflow-providers-google
+google-cloud-batch==0.17.32
     # via apache-airflow-providers-google
 google-cloud-bigquery==3.18.0
     # via google-cloud-aiplatform
     # via pandas-gbq
     # via sqlalchemy-bigquery
-google-cloud-bigquery-datatransfer==3.7.3
+google-cloud-bigquery-datatransfer==3.18.0
     # via apache-airflow-providers-google
-google-cloud-bigtable==1.7.3
+google-cloud-bigtable==2.27.0
     # via apache-airflow-providers-google
-google-cloud-build==3.9.3
+google-cloud-build==3.28.0
     # via apache-airflow-providers-google
-google-cloud-container==2.13.0
+google-cloud-compute==1.23.0
     # via apache-airflow-providers-google
-google-cloud-core==1.7.3
+google-cloud-container==2.55.0
+    # via apache-airflow-providers-google
+google-cloud-core==2.4.1
     # via google-cloud-bigquery
     # via google-cloud-bigtable
     # via google-cloud-logging
     # via google-cloud-spanner
     # via google-cloud-storage
     # via google-cloud-translate
-google-cloud-datacatalog==3.9.3
+google-cloud-datacatalog==3.24.1
     # via apache-airflow-providers-google
-google-cloud-dataform==0.2.3
+google-cloud-dataflow-client==0.8.15
     # via apache-airflow-providers-google
-google-cloud-dataplex==1.1.3
+google-cloud-dataform==0.5.14
     # via apache-airflow-providers-google
-google-cloud-dataproc==5.0.3
+google-cloud-dataplex==2.5.0
     # via apache-airflow-providers-google
-google-cloud-dataproc-metastore==1.6.3
+google-cloud-dataproc==5.11.0
     # via apache-airflow-providers-google
-google-cloud-dlp==1.0.2
+google-cloud-dataproc-metastore==1.17.0
     # via apache-airflow-providers-google
-google-cloud-kms==2.12.3
+google-cloud-dlp==3.26.0
     # via apache-airflow-providers-google
-google-cloud-language==1.3.2
+google-cloud-kms==3.2.1
     # via apache-airflow-providers-google
-google-cloud-logging==3.1.2
+google-cloud-language==2.16.0
     # via apache-airflow-providers-google
-google-cloud-memcache==1.4.4
+google-cloud-logging==3.11.3
+    # via apache-airflow-providers-google
+google-cloud-memcache==1.11.0
     # via apache-airflow-providers-google
 google-cloud-monitoring==2.16.0
     # via apache-airflow-providers-google
-google-cloud-orchestration-airflow==1.4.4
+google-cloud-orchestration-airflow==1.16.0
     # via apache-airflow-providers-google
-google-cloud-os-login==2.7.4
+google-cloud-os-login==2.16.0
     # via apache-airflow-providers-google
-google-cloud-pubsub==2.13.11
+google-cloud-pubsub==2.27.1
     # via apache-airflow-providers-google
-google-cloud-redis==2.9.3
+google-cloud-redis==2.17.0
     # via apache-airflow-providers-google
 google-cloud-resource-manager==1.6.3
     # via google-cloud-aiplatform
-google-cloud-secret-manager==1.0.2
+google-cloud-run==0.10.14
     # via apache-airflow-providers-google
-google-cloud-spanner==1.19.3
+google-cloud-secret-manager==2.22.0
     # via apache-airflow-providers-google
-google-cloud-speech==1.3.4
+google-cloud-spanner==3.51.0
     # via apache-airflow-providers-google
-google-cloud-storage==1.36.2
+    # via sqlalchemy-spanner
+google-cloud-speech==2.29.0
+    # via apache-airflow-providers-google
+google-cloud-storage==2.19.0
     # via airflow
     # via apache-airflow-providers-google
     # via gcsfs
     # via google-cloud-aiplatform
-google-cloud-tasks==2.10.4
+google-cloud-storage-transfer==1.15.0
     # via apache-airflow-providers-google
-google-cloud-texttospeech==1.0.3
+google-cloud-tasks==2.18.0
     # via apache-airflow-providers-google
-google-cloud-translate==1.7.2
+google-cloud-texttospeech==2.23.0
     # via apache-airflow-providers-google
-google-cloud-videointelligence==1.16.3
+google-cloud-translate==3.19.0
     # via apache-airflow-providers-google
-google-cloud-vision==1.0.2
+google-cloud-videointelligence==2.15.0
     # via apache-airflow-providers-google
-google-cloud-workflows==1.7.4
+google-cloud-vision==3.9.0
+    # via apache-airflow-providers-google
+google-cloud-workflows==1.16.0
     # via apache-airflow-providers-google
 google-crc32c==1.5.0
+    # via google-cloud-storage
     # via google-resumable-media
-google-resumable-media==1.3.3
+google-resumable-media==2.7.2
     # via google-cloud-bigquery
     # via google-cloud-storage
 googleapis-common-protos==1.65.0
@@ -359,28 +430,34 @@ greenlet==3.1.1
     # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via google-cloud-bigtable
-    # via google-cloud-container
+    # via google-cloud-build
     # via google-cloud-datacatalog
     # via google-cloud-dataform
     # via google-cloud-dataplex
+    # via google-cloud-dataproc
+    # via google-cloud-dataproc-metastore
     # via google-cloud-kms
     # via google-cloud-logging
     # via google-cloud-pubsub
     # via google-cloud-resource-manager
+    # via google-cloud-run
     # via google-cloud-secret-manager
     # via google-cloud-spanner
     # via google-cloud-tasks
+    # via google-cloud-translate
+grpc-interceptor==0.15.4
+    # via google-cloud-spanner
 grpcio==1.67.1
     # via google-ads
     # via google-api-core
     # via google-cloud-pubsub
     # via googleapis-common-protos
     # via grpc-google-iam-v1
+    # via grpc-interceptor
     # via grpcio-gcp
     # via grpcio-status
 grpcio-gcp==0.2.2
     # via apache-airflow-providers-google
-    # via google-api-core
 grpcio-status==1.48.2
     # via google-ads
     # via google-api-core
@@ -403,6 +480,8 @@ idna==3.10
     # via httpx
     # via requests
     # via yarl
+importlib-metadata==8.5.0
+    # via opentelemetry-api
 inflection==0.5.1
     # via connexion
 influxdb==5.2.1
@@ -490,6 +569,15 @@ oauthlib==3.2.2
     # via requests-oauthlib
 openpyxl==3.1.5
     # via airflow
+opentelemetry-api==1.29.0
+    # via google-cloud-logging
+    # via google-cloud-pubsub
+    # via opentelemetry-sdk
+    # via opentelemetry-semantic-conventions
+opentelemetry-sdk==1.29.0
+    # via google-cloud-pubsub
+opentelemetry-semantic-conventions==0.50b0
+    # via opentelemetry-sdk
 packaging==24.1
     # via apache-airflow
     # via connexion
@@ -524,41 +612,18 @@ propcache==0.2.0
 proto-plus==1.25.0
     # via apache-airflow-providers-google
     # via google-ads
-    # via google-cloud-aiplatform
-    # via google-cloud-appengine-logging
-    # via google-cloud-automl
-    # via google-cloud-bigquery-datatransfer
-    # via google-cloud-build
-    # via google-cloud-container
-    # via google-cloud-datacatalog
-    # via google-cloud-dataform
-    # via google-cloud-dataplex
-    # via google-cloud-dataproc
-    # via google-cloud-dataproc-metastore
-    # via google-cloud-kms
-    # via google-cloud-logging
-    # via google-cloud-memcache
-    # via google-cloud-monitoring
-    # via google-cloud-orchestration-airflow
-    # via google-cloud-os-login
-    # via google-cloud-pubsub
-    # via google-cloud-redis
-    # via google-cloud-resource-manager
-    # via google-cloud-tasks
-    # via google-cloud-workflows
-protobuf==3.20.3
-    # via airflow
-    # via google-ads
     # via google-api-core
     # via google-cloud-aiplatform
     # via google-cloud-appengine-logging
-    # via google-cloud-audit-log
     # via google-cloud-automl
+    # via google-cloud-batch
     # via google-cloud-bigquery-datatransfer
     # via google-cloud-bigtable
     # via google-cloud-build
+    # via google-cloud-compute
     # via google-cloud-container
     # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
     # via google-cloud-dataform
     # via google-cloud-dataplex
     # via google-cloud-dataproc
@@ -574,9 +639,53 @@ protobuf==3.20.3
     # via google-cloud-pubsub
     # via google-cloud-redis
     # via google-cloud-resource-manager
+    # via google-cloud-run
     # via google-cloud-secret-manager
     # via google-cloud-spanner
     # via google-cloud-speech
+    # via google-cloud-storage-transfer
+    # via google-cloud-tasks
+    # via google-cloud-texttospeech
+    # via google-cloud-translate
+    # via google-cloud-videointelligence
+    # via google-cloud-vision
+    # via google-cloud-workflows
+protobuf==3.20.3
+    # via airflow
+    # via google-ads
+    # via google-api-core
+    # via google-cloud-aiplatform
+    # via google-cloud-appengine-logging
+    # via google-cloud-audit-log
+    # via google-cloud-automl
+    # via google-cloud-batch
+    # via google-cloud-bigquery-datatransfer
+    # via google-cloud-bigtable
+    # via google-cloud-build
+    # via google-cloud-compute
+    # via google-cloud-container
+    # via google-cloud-datacatalog
+    # via google-cloud-dataflow-client
+    # via google-cloud-dataform
+    # via google-cloud-dataplex
+    # via google-cloud-dataproc
+    # via google-cloud-dataproc-metastore
+    # via google-cloud-dlp
+    # via google-cloud-kms
+    # via google-cloud-language
+    # via google-cloud-logging
+    # via google-cloud-memcache
+    # via google-cloud-monitoring
+    # via google-cloud-orchestration-airflow
+    # via google-cloud-os-login
+    # via google-cloud-pubsub
+    # via google-cloud-redis
+    # via google-cloud-resource-manager
+    # via google-cloud-run
+    # via google-cloud-secret-manager
+    # via google-cloud-spanner
+    # via google-cloud-speech
+    # via google-cloud-storage-transfer
     # via google-cloud-tasks
     # via google-cloud-texttospeech
     # via google-cloud-translate
@@ -591,10 +700,11 @@ psutil==6.1.0
     # via apache-airflow
 py4j==0.10.9.7
     # via pyspark
-pyasn1==0.6.1
+pyasn1==0.5.1
     # via pyasn1-modules
     # via rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.3.0
+    # via gcloud-aio-storage
     # via google-auth
 pyathena==1.9.0
     # via airflow
@@ -615,9 +725,10 @@ pyjwt==2.9.0
     # via apache-airflow
     # via flask-appbuilder
     # via flask-jwt-extended
+    # via gcloud-aio-auth
 pymeta3==0.5.1
     # via pybars3
-pyopenssl==24.2.1
+pyopenssl==23.2.0
     # via apache-airflow-providers-google
 pyparsing==3.1.4
     # via httplib2
@@ -691,6 +802,7 @@ rpds-py==0.20.0
     # via jsonschema
     # via referencing
 rsa==4.9
+    # via gcloud-aio-storage
     # via google-auth
 s3transfer==0.10.3
     # via boto3
@@ -700,7 +812,6 @@ setproctitle==1.3.3
     # via apache-airflow
 setuptools==75.3.0
     # via google-ads
-    # via google-auth
     # via influxdb-client
     # via kubernetes
     # via pandas-gbq
@@ -710,10 +821,7 @@ setuptools==75.3.0
 shapely==2.0.6
     # via google-cloud-aiplatform
 six==1.16.0
-    # via google-api-python-client
-    # via google-auth
-    # via google-cloud-core
-    # via google-resumable-media
+    # via gcloud-aio-auth
     # via influxdb
     # via kubernetes
     # via prison
@@ -735,6 +843,7 @@ sqlalchemy==1.4.46
     # via sqlalchemy-bigquery
     # via sqlalchemy-jsonfield
     # via sqlalchemy-redshift
+    # via sqlalchemy-spanner
     # via sqlalchemy-utils
 sqlalchemy-bigquery==1.12.0
     # via apache-airflow-providers-google
@@ -742,10 +851,13 @@ sqlalchemy-jsonfield==1.0.2
     # via apache-airflow
 sqlalchemy-redshift==0.8.14
     # via apache-airflow-providers-amazon
+sqlalchemy-spanner==1.8.0
+    # via apache-airflow-providers-google
 sqlalchemy-utils==0.41.2
     # via flask-appbuilder
 sqlparse==0.5.1
     # via apache-airflow-providers-common-sql
+    # via google-cloud-spanner
 tabulate==0.9.0
     # via apache-airflow
 tenacity==9.0.0
@@ -766,6 +878,7 @@ typing-extensions==4.12.2
     # via mypy-boto3-appflow
     # via mypy-boto3-rds
     # via mypy-boto3-redshift-data
+    # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
     # via reactivex
@@ -804,3 +917,5 @@ wtforms==3.1.2
     # via flask-wtf
 yarl==1.15.2
     # via aiohttp
+zipp==3.21.0
+    # via importlib-metadata


### PR DESCRIPTION
**Overview**: To effectively integrate Dataproc with our Airflow environment, we need to modify the `internal_ip_only` setting from `true` to `false`. This change requires upgrading the `google-cloud-dataproc` package within Airflow.

**Challenges**:
 Dependency Constraints: Upgrading `google-cloud-dataproc` necessitates updates to several dependent packages. However, due to compatibility issues, we cannot upgrade `apache-airflow` from version `2.5.1` to `2.8.0`.

**Proposed Solution**: Upgrade the following packages to resolve dependency conflicts and support the necessary `google-cloud-dataproc` update without altering the current version of Apache Airflow:

* `google-api-python-client`
* `google-cloud-storage`
* `apache-airflow-providers-google`


I confirm that I have added:

- [ ] A comment to every Dockerfile with information about target repository and tag (version).
- [ ] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
