### PR TITLE
ADS-4800: Remove pubnative dockerhub images - pubnative/sbt-ci

### DIFF
--- a/sbt-ci/Dockerfile
+++ b/sbt-ci/Dockerfile
@@ -1,4 +1,4 @@
-# Image pubnative/sbt-ci:0.15
+# Image us-docker.pkg.dev/vgi-pn-277619/data-team/pubnative/sbt-ci:0.15
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
I confirm that I have added:

- [ ] A comment to every Dockerfile with information about target repository and tag (version).
- [ ] Filled in readme on dockerhub and in this repo about how to build the image if some extra steps should be done.
